### PR TITLE
Validation rule to check PHN is 10 digits

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/objects/Case/fields/PHN_No__c.field-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/objects/Case/fields/PHN_No__c.field-meta.xml
@@ -3,12 +3,11 @@
     <fullName>PHN_No__c</fullName>
     <externalId>false</externalId>
     <label>PHN</label>
-    <precision>18</precision>
-    <required>true</required>
-    <scale>0</scale>
+    <length>10</length>
+    <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Number</type>
+    <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/MAiD - Case Management App/force-app/main/default/objects/Case/validationRules/Validates_PHN_is_10_digits_if_it_is_BC.validationRule-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/objects/Case/validationRules/Validates_PHN_is_10_digits_if_it_is_BC.validationRule-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Validates_PHN_is_10_digits_if_it_is_BC</fullName>
+    <active>true</active>
+    <errorConditionFormula>ISPICKVAL(Province_or_Territory_that_issued_PHN__c , &apos;59 - British Columbia&apos;) &amp;&amp;  NOT(LEN( PHN_No__c ) == 10)</errorConditionFormula>
+    <errorMessage>PHN must be 10 digits if BC is selected as Province or Territory that issued PHN</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
Component added - Validation Rule 
If BC is selected, then the PHN must be 10 digits 