### PR TITLE
Defect changes for duplicate PHN Notification Flow

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/display_warning_for_duplicate_phn.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/display_warning_for_duplicate_phn.flow-meta.xml
@@ -42,6 +42,35 @@
             <label>check collection has existing phn</label>
         </rules>
     </decisions>
+    <decisions>
+        <name>check_the_case_type</name>
+        <label>check the case type</label>
+        <locationX>413</locationX>
+        <locationY>190</locationY>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>check_case_type</name>
+            <conditionLogic>or</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Ineligible</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>assign_value_to_existing_PHN</targetReference>
+            </connector>
+            <label>check case type</label>
+        </rules>
+    </decisions>
     <description>This flow is responsible to check if a new case is being created with the same PHN already in the system.</description>
     <interviewLabel>display warning for duplicate phn {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Display warning for duplicate phn</label>
@@ -110,7 +139,7 @@
         <connector>
             <targetReference>loop_through_all_phn</targetReference>
         </connector>
-        <filterLogic>(1 AND 2) OR (3 AND 4) OR (5 AND 6)</filterLogic>
+        <filterLogic>(1 AND 2)</filterLogic>
         <filters>
             <field>Type</field>
             <operator>EqualTo</operator>
@@ -121,34 +150,6 @@
         <filters>
             <field>Status</field>
             <operator>EqualTo</operator>
-            <value>
-                <stringValue>Closed</stringValue>
-            </value>
-        </filters>
-        <filters>
-            <field>Type</field>
-            <operator>NotEqualTo</operator>
-            <value>
-                <elementReference>$Record.Type</elementReference>
-            </value>
-        </filters>
-        <filters>
-            <field>Status</field>
-            <operator>EqualTo</operator>
-            <value>
-                <stringValue>Closed</stringValue>
-            </value>
-        </filters>
-        <filters>
-            <field>Type</field>
-            <operator>NotEqualTo</operator>
-            <value>
-                <elementReference>$Record.Type</elementReference>
-            </value>
-        </filters>
-        <filters>
-            <field>Status</field>
-            <operator>NotEqualTo</operator>
             <value>
                 <stringValue>Closed</stringValue>
             </value>
@@ -185,10 +186,10 @@
         <inputReference>$Record</inputReference>
     </recordUpdates>
     <start>
-        <locationX>121</locationX>
-        <locationY>70</locationY>
+        <locationX>15</locationX>
+        <locationY>76</locationY>
         <connector>
-            <targetReference>assign_value_to_existing_PHN</targetReference>
+            <targetReference>check_the_case_type</targetReference>
         </connector>
         <object>Case</object>
         <recordTriggerType>Create</recordTriggerType>


### PR DESCRIPTION
Defect Changes for new PHN Flow

A. Notifications can be generated only for the type :

Discontinuation of Planning: Ineligible
Discontinuation of Planning: Withdrawn Request
B. Status : Closed

