### PR TITLE
update admin permission for viewAllData (False)

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_System_Administrator.permissionset-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_System_Administrator.permissionset-meta.xml
@@ -4615,7 +4615,7 @@
         <name>UseWebLink</name>
     </userPermissions>
     <userPermissions>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <name>ViewAllData</name>
     </userPermissions>
     <userPermissions>


### PR DESCRIPTION
update admin permission  set to update viewAllData to false in order not to have permission to ActiveScratchOrg
ScratchOrgInfo; NamespaceRegistry as required