### PR TITLE
Adding Historical Case Owner Field

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/objects/Case/fields/Historical_Case_Reviewer__c.field-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/objects/Case/fields/Historical_Case_Reviewer__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Historical_Case_Reviewer__c</fullName>
+    <encryptionScheme>None</encryptionScheme>
+    <externalId>false</externalId>
+    <label>Historical Case Reviewer</label>
+    <length>40</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Analyst.permissionset-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Analyst.permissionset-meta.xml
@@ -140,6 +140,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Case.Historical_Case_Reviewer__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Case.If_1632_Incomplete__c</field>
         <readable>true</readable>

--- a/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Manager.permissionset-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Manager.permissionset-meta.xml
@@ -140,6 +140,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Case.Historical_Case_Reviewer__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Case.If_1632_Incomplete__c</field>
         <readable>true</readable>

--- a/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_System_Administrator.permissionset-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_System_Administrator.permissionset-meta.xml
@@ -141,6 +141,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Case.Historical_Case_Reviewer__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Case.If_1632_Incomplete__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Adding Historical Case Owner Field

Files effected:
1. MAiD Analyst Permission Sets - Read Only
2. MAiD Manager Permission Sets - Read Only
3. MAiD System Admin Permission Sets- Edit
4. New Field Addition as - Historical Case Owner from the backend
