### PR TITLE
BCMOHAD-14191 New criteria added in  Rule 27

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Provincial_Safeguards.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Provincial_Safeguards.flow-meta.xml
@@ -537,7 +537,7 @@
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>CheckRule27_yes</name>
-            <conditionLogic>(1 AND 2 AND 3 AND 4 AND 5 AND 6 AND 7 AND (8 OR 9))  OR (10 AND 11)</conditionLogic>
+            <conditionLogic>(1 AND 2 AND 3 AND 4 AND 5 AND 6 AND 7 AND 12 AND (8 OR 9))  OR (10 AND 11)</conditionLogic>
             <conditions>
                 <leftValueReference>Var1634_PractitionersSignature</leftValueReference>
                 <operator>EqualTo</operator>
@@ -608,6 +608,10 @@
                 <rightValue>
                     <stringValue>MAiD Death Not Foreseeable</stringValue>
                 </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Potential_BCCS_Review</leftValueReference>
+                <operator>NotEqualTo</operator>
             </conditions>
             <connector>
                 <targetReference>CheckRule28</targetReference>
@@ -2316,6 +2320,10 @@
             <field>Patient_was_given_opportunity_to_withdra__c</field>
         </outputAssignments>
         <outputAssignments>
+            <assignToReference>Var1634_Potential_BCCS_Review</assignToReference>
+            <field>Potential_BCCS_Review__c</field>
+        </outputAssignments>
+        <outputAssignments>
             <assignToReference>Var1634_PractitionerAdministrationsignoffDat1</assignToReference>
             <field>Practitioner_Administration_sign_off_Dat__c</field>
         </outputAssignments>
@@ -2872,6 +2880,13 @@
     <variables>
         <name>Var1634_Patientwasgivenopportunitytowithdra</name>
         <dataType>Boolean</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_Potential_BCCS_Review</name>
+        <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
         <isOutput>false</isOutput>


### PR DESCRIPTION
New  criteria field "Potential_BCCS_Review" made mandatory in the element Rule 27 in the Porvincial_Safeguard flow.