### PR TITLE
BCMOHAD-14195 -Rule 20, 25,26,33,42,50 -Updates

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -212,8 +212,8 @@
     <assignments>
         <name>Rule_26_Message_Assignment</name>
         <label>Rule 26 Message Assignment</label>
-        <locationX>1732</locationX>
-        <locationY>887</locationY>
+        <locationX>1492</locationX>
+        <locationY>1101</locationY>
         <assignmentItems>
             <assignToReference>ListCaseDetail.Mandatory_Data_Feedback_Message__c</assignToReference>
             <operator>Assign</operator>
@@ -228,8 +228,8 @@
     <assignments>
         <name>Rule_32_Message_Assignment</name>
         <label>Rule 32 Message Assignment</label>
-        <locationX>1579</locationX>
-        <locationY>1007</locationY>
+        <locationX>1499</locationX>
+        <locationY>1177</locationY>
         <assignmentItems>
             <assignToReference>ListCaseDetail.Mandatory_Data_Feedback_Message__c</assignToReference>
             <operator>Assign</operator>
@@ -792,8 +792,8 @@
     <decisions>
         <name>Check_if_Rule_50_Multiselect_list_is_empty</name>
         <label>Check if Rule 50 Multiselect list is empty</label>
-        <locationX>2685</locationX>
-        <locationY>1300</locationY>
+        <locationX>2611</locationX>
+        <locationY>1135</locationY>
         <defaultConnector>
             <targetReference>Rule_50</targetReference>
         </defaultConnector>
@@ -892,8 +892,8 @@
     <decisions>
         <name>Rule24</name>
         <label>Rule 24</label>
-        <locationX>1730</locationX>
-        <locationY>655</locationY>
+        <locationX>1755</locationX>
+        <locationY>605</locationY>
         <defaultConnector>
             <targetReference>Rule_24_Message_Assignment</targetReference>
         </defaultConnector>
@@ -961,7 +961,7 @@
                 <operator>EqualTo</operator>
             </conditions>
             <connector>
-                <targetReference>Rule_25</targetReference>
+                <targetReference>Rule_25_Case_Type_checking</targetReference>
             </connector>
             <label>Rule 24 Pass</label>
         </rules>
@@ -985,8 +985,8 @@
     <decisions>
         <name>Rule_20</name>
         <label>Rule 20</label>
-        <locationX>1225</locationX>
-        <locationY>267</locationY>
+        <locationX>1209</locationX>
+        <locationY>245</locationY>
         <defaultConnector>
             <targetReference>Rule_20_Message_Assignment</targetReference>
         </defaultConnector>
@@ -1109,10 +1109,7 @@
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_Patientneedsdisabilitysupportservice</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>1 - Yes</stringValue>
-                </rightValue>
+                <operator>NotEqualTo</operator>
             </conditions>
             <conditions>
                 <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
@@ -1180,15 +1177,29 @@
     <decisions>
         <name>Rule_25</name>
         <label>Rule 25</label>
-        <locationX>1596</locationX>
-        <locationY>815</locationY>
+        <locationX>1559</locationX>
+        <locationY>973</locationY>
         <defaultConnector>
             <targetReference>Rule_25_Message_Assignment</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Rule 25 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_25_Pass</name>
-            <conditionLogic>(1 AND 2) OR (3 AND 4) OR 5 OR 6</conditionLogic>
+            <conditionLogic>(1 AND 2) OR (2 AND 3 AND 4) OR (2 AND 5 AND 6) OR (7 AND (8 OR 9)) OR (7 AND 10 AND 1) OR ( 7 AND 10 AND 5 AND 6) OR (7 AND 10 AND 3 AND 4 AND 11 AND 14 AND ((12 AND 13) OR (NOT(12))))</conditionLogic>
+            <conditions>
+                <leftValueReference>Var1634_Patientreceivedpalliativecare</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>3 - Do not know</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
+                <operator>LessThan</operator>
+                <rightValue>
+                    <elementReference>VarCase_CaseTypeReporteddate</elementReference>
+                </rightValue>
+            </conditions>
             <conditions>
                 <leftValueReference>Var1634_Patientreceivedpalliativecare</leftValueReference>
                 <operator>EqualTo</operator>
@@ -1198,10 +1209,7 @@
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_If_yes_for_how_long_1</leftValueReference>
-                <operator>IsNull</operator>
-                <rightValue>
-                    <booleanValue>false</booleanValue>
-                </rightValue>
+                <operator>NotEqualTo</operator>
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_Patientreceivedpalliativecare</leftValueReference>
@@ -1212,26 +1220,112 @@
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_If_no_was_palliative_care_accessible</leftValueReference>
-                <operator>IsNull</operator>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
+                <operator>GreaterThanOrEqualTo</operator>
                 <rightValue>
-                    <booleanValue>false</booleanValue>
+                    <elementReference>VarCase_CaseTypeReporteddate</elementReference>
                 </rightValue>
             </conditions>
             <conditions>
-                <leftValueReference>Var1634_Patientreceivedpalliativecare</leftValueReference>
-                <operator>EqualTo</operator>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_Patientreceivedpalliativecare</leftValueReference>
+                <leftValueReference>Var1634_Patient_required_palliative_care</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
-                    <stringValue>3 - Do not know</stringValue>
+                    <stringValue>No</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Patient_required_palliative_care</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Do not know</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Patient_required_palliative_care</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Yes</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Location_of_Palliative_care</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Types_of_palliative_care_received</leftValueReference>
+                <operator>Contains</operator>
+                <rightValue>
+                    <stringValue>Other</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_If_other_type_specify</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Types_of_palliative_care_received</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <connector>
+                <targetReference>Rule_26_Case_Type_checking</targetReference>
+            </connector>
+            <label>Rule 25 Pass</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>Rule_25_Case_Type_checking</name>
+        <label>Rule 25 Case_Type checking</label>
+        <locationX>1574</locationX>
+        <locationY>707</locationY>
+        <defaultConnector>
+            <targetReference>Rule_26_Case_Type_checking</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>default</defaultConnectorLabel>
+        <rules>
+            <name>Rule_25_Case_Type_check_true</name>
+            <conditionLogic>1 OR 2 OR 3 OR 4 OR 5</conditionLogic>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Not Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Death Prior</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Ineligible</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
                 </rightValue>
             </conditions>
             <connector>
-                <targetReference>Rule_26</targetReference>
+                <targetReference>Rule_25</targetReference>
             </connector>
-            <label>Rule 25 Pass</label>
+            <label>Rule 25 Case Type check true</label>
         </rules>
     </decisions>
     <decisions>
@@ -1245,72 +1339,143 @@
         <defaultConnectorLabel>Rule 26 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_26_Pass</name>
-            <conditionLogic>(1 AND 3 AND 4 AND 9) OR (1 AND 2 AND 5 AND 8) OR (1 AND 10 AND 8 AND 9) OR (6 AND 7 AND 8 AND 9)</conditionLogic>
+            <conditionLogic>3 OR ((1 OR 10) AND 2) OR ((1 OR 10) AND 4 AND 5) OR ((1 OR 10) AND 4 AND 7 AND 6) OR (1 AND 4 AND 8 AND 9) OR (10 AND 4 AND 8 AND 9 AND 12 AND ((11 AND 13) OR (NOT(11))))</conditionLogic>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
+                <operator>LessThan</operator>
+                <rightValue>
+                    <elementReference>VarCase_CaseTypeReporteddate</elementReference>
+                </rightValue>
+            </conditions>
             <conditions>
                 <leftValueReference>Var1634_Patientneedsdisabilitysupportservice</leftValueReference>
-                <operator>Contains</operator>
+                <operator>EqualTo</operator>
                 <rightValue>
-                    <stringValue>Yes</stringValue>
+                    <stringValue>2 - No</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Patientneedsdisabilitysupportservice</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>3 - Do not know</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Patientneedsdisabilitysupportservice</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>1 - Yes</stringValue>
                 </rightValue>
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_If_yes_did_patient_received_disability</leftValueReference>
-                <operator>Contains</operator>
+                <operator>EqualTo</operator>
                 <rightValue>
-                    <stringValue>No</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_If_yes_did_patient_received_disability</leftValueReference>
-                <operator>Contains</operator>
-                <rightValue>
-                    <stringValue>Yes</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_If_yes_for_how_long</leftValueReference>
-                <operator>IsNull</operator>
-                <rightValue>
-                    <booleanValue>false</booleanValue>
+                    <stringValue>3 - Do not know</stringValue>
                 </rightValue>
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_If_no_were_services_accessible</leftValueReference>
-                <operator>IsNull</operator>
-                <rightValue>
-                    <booleanValue>false</booleanValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_Patientneedsdisabilitysupportservice</leftValueReference>
                 <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_If_yes_did_patient_received_disability</leftValueReference>
+                <operator>EqualTo</operator>
                 <rightValue>
-                    <stringValue>Yes</stringValue>
+                    <stringValue>2- No</stringValue>
                 </rightValue>
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_If_yes_did_patient_received_disability</leftValueReference>
                 <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>1-Yes</stringValue>
+                </rightValue>
             </conditions>
             <conditions>
                 <leftValueReference>Var1634_If_yes_for_how_long</leftValueReference>
-                <operator>EqualTo</operator>
+                <operator>NotEqualTo</operator>
             </conditions>
             <conditions>
-                <leftValueReference>Var1634_If_no_were_services_accessible</leftValueReference>
-                <operator>EqualTo</operator>
+                <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
+                <operator>GreaterThanOrEqualTo</operator>
+                <rightValue>
+                    <elementReference>VarCase_CaseTypeReporteddate</elementReference>
+                </rightValue>
             </conditions>
             <conditions>
-                <leftValueReference>Var1634_If_yes_did_patient_received_disability</leftValueReference>
+                <leftValueReference>Var1634_Disability_support_services_received</leftValueReference>
                 <operator>Contains</operator>
                 <rightValue>
-                    <stringValue>Do not know</stringValue>
+                    <stringValue>Other supports</stringValue>
                 </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Disability_support_services_received</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Other_supports_specify</leftValueReference>
+                <operator>NotEqualTo</operator>
             </conditions>
             <connector>
                 <targetReference>Rule_32</targetReference>
             </connector>
             <label>Rule 26 Pass</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>Rule_26_Case_Type_checking</name>
+        <label>Rule 26 Case_Type checking</label>
+        <locationX>1782</locationX>
+        <locationY>717</locationY>
+        <defaultConnector>
+            <targetReference>Rule_32</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>default</defaultConnectorLabel>
+        <rules>
+            <name>Rule_26_Case_Type_check_TRUE</name>
+            <conditionLogic>1 OR 2 OR 3 OR 4 OR 5</conditionLogic>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Not Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Death Prior</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Ineligible</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Rule_26</targetReference>
+            </connector>
+            <label>Rule 26 Case_Type check TRUE</label>
         </rules>
     </decisions>
     <decisions>
@@ -1397,27 +1562,20 @@
     <decisions>
         <name>Rule_33</name>
         <label>Rule 33</label>
-        <locationX>2061</locationX>
-        <locationY>918</locationY>
+        <locationX>1973</locationX>
+        <locationY>930</locationY>
         <defaultConnector>
             <targetReference>Rule_33_Message_Assignment</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Rule 33 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_33_Pass</name>
-            <conditionLogic>(((1 OR 7) AND 2 AND 6) OR ((1 OR 7) AND 2 AND 5 AND 3)) OR (4 AND 8) OR 9</conditionLogic>
+            <conditionLogic>(3 AND 7) OR 5 OR 8 OR ( (14 AND 4 AND ( 2 OR 9) )  AND ( (12 AND 10)  OR (NOT(12)) ) AND ( (13 AND 11) OR (NOT(13)) ) AND (1 OR 6))</conditionLogic>
             <conditions>
                 <leftValueReference>ListCaseDetail.Type</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>MAiD Death Foreseeable</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_Was_patient_transferred_for_MAiD</leftValueReference>
-                <operator>IsNull</operator>
-                <rightValue>
-                    <booleanValue>false</booleanValue>
                 </rightValue>
             </conditions>
             <conditions>
@@ -1469,6 +1627,36 @@
                     <stringValue>3 - Do not know</stringValue>
                 </rightValue>
             </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Reasons_for_transfer</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Specify_other_transfer_reason</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Name_of_facility_if_due_to_MAiD_policy</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Reasons_for_transfer</leftValueReference>
+                <operator>Contains</operator>
+                <rightValue>
+                    <stringValue>Other</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Reasons_for_transfer</leftValueReference>
+                <operator>Contains</operator>
+                <rightValue>
+                    <stringValue>Policies of the facility where the person was located</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Was_patient_transferred_for_MAiD</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
             <connector>
                 <targetReference>Rule_44</targetReference>
             </connector>
@@ -1478,15 +1666,15 @@
     <decisions>
         <name>Rule_42</name>
         <label>Rule 42</label>
-        <locationX>1220</locationX>
-        <locationY>526</locationY>
+        <locationX>1163</locationX>
+        <locationY>497</locationY>
         <defaultConnector>
             <targetReference>Rule_42_Message_Assignment</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Rule 42 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_42_Pass</name>
-            <conditionLogic>((1 AND 2 AND 3 AND 4 AND 5 AND 6) AND (7 OR 8 OR 9)) OR (10 AND 11 AND 12)</conditionLogic>
+            <conditionLogic>((( 14 AND 1 AND 2 AND 3 AND 4 AND 5 AND 6 ) OR (1 AND 2 AND 3 AND 4 AND 5 AND 6 AND 13)) AND (7 OR 8 OR 9)) OR (10 AND 11 AND 12)</conditionLogic>
             <conditions>
                 <leftValueReference>Var1634_PriorPatientConsultation</leftValueReference>
                 <operator>IsNull</operator>
@@ -1569,6 +1757,17 @@
                 <operator>NotEqualTo</operator>
                 <rightValue>
                     <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Written_or_verbal_request_date</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
+                <operator>LessThan</operator>
+                <rightValue>
+                    <elementReference>VarCase_CaseTypeReporteddate</elementReference>
                 </rightValue>
             </conditions>
             <connector>
@@ -2001,7 +2200,7 @@
         </rules>
         <rules>
             <name>Rule_50_Pass</name>
-            <conditionLogic>(1 AND ((2 AND 3 AND 4 AND 5) OR 6)) OR 7</conditionLogic>
+            <conditionLogic>(( 1  AND (2 AND (3 OR 9)) AND ((4 AND 5) OR (NOT(4))) AND ( (10 AND 11) OR (NOT(10))) AND (( 8 AND 12) OR 15) AND ( ( (8 AND 13 AND 14) OR (NOT(13)) ) OR 15 )  )   OR 6 )  OR 7</conditionLogic>
             <conditions>
                 <leftValueReference>ListCaseDetail.Type</leftValueReference>
                 <operator>EqualTo</operator>
@@ -2031,7 +2230,7 @@
                 </rightValue>
             </conditions>
             <conditions>
-                <leftValueReference>Var1634_If_other_specify_3_Pt_Withdreq_req</leftValueReference>
+                <leftValueReference>Var1634_If_other_specify</leftValueReference>
                 <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>false</booleanValue>
@@ -2049,6 +2248,50 @@
                 <operator>NotEqualTo</operator>
                 <rightValue>
                     <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
+                <operator>GreaterThanOrEqualTo</operator>
+                <rightValue>
+                    <elementReference>VarCase_CaseTypeReporteddate</elementReference>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_If_known_reasons_for_withdrawal</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_If_known_reasons_for_withdrawal</leftValueReference>
+                <operator>Contains</operator>
+                <rightValue>
+                    <stringValue>Other reason</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Specify_other_withdrawal_reason</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Withdrawal_means_to_relieve_suffering</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Withdrawal_means_to_relieve_suffering</leftValueReference>
+                <operator>Contains</operator>
+                <rightValue>
+                    <stringValue>Other</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Other_relief_means_specify</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
+                <operator>LessThan</operator>
+                <rightValue>
+                    <elementReference>VarCase_CaseTypeReporteddate</elementReference>
                 </rightValue>
             </conditions>
             <connector>
@@ -2723,7 +2966,7 @@
             <label>Skip Rule</label>
         </rules>
     </decisions>
-    <description>Updating Rule : 20- V1</description>
+    <description>Rule 50 : Testing 3</description>
     <environments>Default</environments>
     <formulas>
         <name>FormatedAddSemicolon</name>
@@ -2976,6 +3219,10 @@
             <field>Did_practitioner_complete_medical_certi__c</field>
         </outputAssignments>
         <outputAssignments>
+            <assignToReference>Var1634_Disability_support_services_received</assignToReference>
+            <field>Disability_support_services_received__c</field>
+        </outputAssignments>
+        <outputAssignments>
             <assignToReference>Var1634_I_determine_Patient</assignToReference>
             <field>I_determine_that_the_patient__c</field>
         </outputAssignments>
@@ -2990,6 +3237,10 @@
         <outputAssignments>
             <assignToReference>Var1634_If_Yes_Practitioner_became_aware</assignToReference>
             <field>If_Yes_practitioner_became_aware_patien__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_If_known_reasons_for_withdrawal</assignToReference>
+            <field>If_known_reasons_for_withdrawal__c</field>
         </outputAssignments>
         <outputAssignments>
             <assignToReference>Var1634_date_of_death_unkown</assignToReference>
@@ -3014,6 +3265,14 @@
         <outputAssignments>
             <assignToReference>Var1634_If_other_specify_4</assignToReference>
             <field>If_other_specify_4__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_If_other_specify</assignToReference>
+            <field>If_other_specify__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_If_other_type_specify</assignToReference>
+            <field>If_other_type_specify__c</field>
         </outputAssignments>
         <outputAssignments>
             <assignToReference>Var1634_If_patient_directly_other_specify</assignToReference>
@@ -3056,6 +3315,10 @@
             <field>Location_of_Assessment__c</field>
         </outputAssignments>
         <outputAssignments>
+            <assignToReference>Var1634_Location_of_Palliative_care</assignToReference>
+            <field>Location_of_Palliative_care__c</field>
+        </outputAssignments>
+        <outputAssignments>
             <assignToReference>Var1634_MAiDLocationAdress</assignToReference>
             <field>MAiD_Location_Address__c</field>
         </outputAssignments>
@@ -3064,8 +3327,20 @@
             <field>MAiD_Location_Type__c</field>
         </outputAssignments>
         <outputAssignments>
+            <assignToReference>Var1634_Name_of_facility_if_due_to_MAiD_policy</assignToReference>
+            <field>Name_of_facility_if_due_to_MAiD_policy__c</field>
+        </outputAssignments>
+        <outputAssignments>
             <assignToReference>Var1634_Other_natural_death_reason</assignToReference>
             <field>Other_natural_death_reason__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_Other_relief_means_specify</assignToReference>
+            <field>Other_relief_means_specify__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_Other_supports_specify</assignToReference>
+            <field>Other_supports_specify__c</field>
         </outputAssignments>
         <outputAssignments>
             <assignToReference>Var1634_Patient_lost_capability_to_consent</assignToReference>
@@ -3096,8 +3371,24 @@
             <field>Profession_if_yes_select_all_that_apply__c</field>
         </outputAssignments>
         <outputAssignments>
+            <assignToReference>Var1634_Reasons_for_transfer</assignToReference>
+            <field>Reasons_for_transfer__c</field>
+        </outputAssignments>
+        <outputAssignments>
             <assignToReference>Var1634_Secondassessorwasaphysicianornurse</assignToReference>
             <field>Second_assessor_was_a_physcian_or_nurse__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_Specify_other_transfer_reason</assignToReference>
+            <field>Specify_other_transfer_reason__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_Specify_other_withdrawal_reason</assignToReference>
+            <field>Specify_other_withdrawal_reason__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_Types_of_palliative_care_received</assignToReference>
+            <field>Types_of_palliative_care_received__c</field>
         </outputAssignments>
         <outputAssignments>
             <assignToReference>Var1634_Underlying_reason_s_of_death_1</assignToReference>
@@ -3110,6 +3401,10 @@
         <outputAssignments>
             <assignToReference>Var1634_Who_did_you_receive_the_written_request</assignToReference>
             <field>Who_did_you_receive_the_written_request__c</field>
+        </outputAssignments>
+        <outputAssignments>
+            <assignToReference>Var1634_Withdrawal_means_to_relieve_suffering</assignToReference>
+            <field>Withdrawal_means_to_relieve_suffering__c</field>
         </outputAssignments>
         <outputAssignments>
             <assignToReference>Var1634_Written_or_verbal_request_date</assignToReference>
@@ -3252,7 +3547,7 @@
         <recordTriggerType>CreateAndUpdate</recordTriggerType>
         <triggerType>RecordAfterSave</triggerType>
     </start>
-    <status>Draft</status>
+    <status>Active</status>
     <variables>
         <name>extractedPicklist_Rule24</name>
         <dataType>String</dataType>
@@ -3483,7 +3778,21 @@
         <isOutput>false</isOutput>
     </variables>
     <variables>
+        <name>Var1634_Disability_support_services_received</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
         <name>Var1634_I_determine_Patient</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_If_known_reasons_for_withdrawal</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
@@ -3511,6 +3820,13 @@
         <isOutput>false</isOutput>
     </variables>
     <variables>
+        <name>Var1634_If_other_specify</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
         <name>Var1634_If_other_specify_3_Pt_Withdreq_req</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
@@ -3519,6 +3835,13 @@
     </variables>
     <variables>
         <name>Var1634_If_other_specify_4</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_If_other_type_specify</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
@@ -3616,6 +3939,13 @@
         <isOutput>false</isOutput>
     </variables>
     <variables>
+        <name>Var1634_Location_of_Palliative_care</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
         <name>Var1634_LocationOfAssessment</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
@@ -3637,7 +3967,28 @@
         <isOutput>false</isOutput>
     </variables>
     <variables>
+        <name>Var1634_Name_of_facility_if_due_to_MAiD_policy</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>true</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
         <name>Var1634_Other_natural_death_reason</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_Other_relief_means_specify</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_Other_supports_specify</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
@@ -3707,7 +4058,35 @@
         <isOutput>false</isOutput>
     </variables>
     <variables>
+        <name>Var1634_Reasons_for_transfer</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
         <name>Var1634_Secondassessorwasaphysicianornurse</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_Specify_other_transfer_reason</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_Specify_other_withdrawal_reason</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_Types_of_palliative_care_received</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
@@ -3736,6 +4115,13 @@
     </variables>
     <variables>
         <name>Var1634_Who_did_you_receive_the_written_request</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>Var1634_Withdrawal_means_to_relieve_suffering</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
@@ -3911,5 +4297,13 @@
         <value>
             <dateValue>2023-01-01</dateValue>
         </value>
+    </variables>
+    <variables>
+        <name>VarRule25formula</name>
+        <dataType>Number</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <scale>0</scale>
     </variables>
 </Flow>

--- a/MAiD - Case Management App/force-app/main/default/layouts/Form_1634__c-Form 1634 Layout.layout-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/layouts/Form_1634__c-Form 1634 Layout.layout-meta.xml
@@ -509,6 +509,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>If_the_patient_withdrew_request_what_we__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>If_other_specify_3__c</field>
             </layoutItems>
             <layoutItems>
@@ -852,6 +856,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Specify_other_transfer_reason__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>If_transferred_was_it_due_to_facility_po__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>

--- a/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Analyst.permissionset-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Analyst.permissionset-meta.xml
@@ -1736,16 +1736,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>Form_1634__c.If_the_patient_withdrew_request_what_we__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>Form_1634__c.If_transferred_was_it_due_to_facility_po__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
         <field>Form_1634__c.If_yes_cause_of_death_Specify__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Manager.permissionset-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsets/MAiD_Manager.permissionset-meta.xml
@@ -1661,16 +1661,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>Form_1634__c.If_the_patient_withdrew_request_what_we__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>Form_1634__c.If_transferred_was_it_due_to_facility_po__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
         <field>Form_1634__c.If_yes_cause_of_death_Specify__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Flow : Mandatory Flow


Rule 20 : BCMOHAD – 14193
PR is already created before , only just condition change in decision box.
Current Logic : ((1 AND 2 AND 16  AND 3 AND 4 AND 5 AND 6 AND 7 AND 17 AND 9 AND 10 AND 11 AND 18 AND 19) OR (1 AND 2 AND 3 AND 4 AND 5 AND 6 AND 7 AND 8 AND 9 AND 10 AND 11 AND 20) AND (12 OR 13)) OR (14 AND 15)

Rule 25 : BCMOHAD -14195
Section: Palliative Care                                                                                                                                                                                                                        
New  field Added with Variable :-  Location of Palliative Care -  Location_of_Palliative_care__c.field-meta.xml  -{!Var1634_Location_of_Palliative_care} , Types of palliative care received -  Types_of_palliative_care_received__c.field-meta.xml  {!Var1634_Types_of_palliative_care_received} , If other type, specify - If_other_type_specify__c.field-meta.xml  - {!Var1634_If_other_type_specify}

Rule 25:

-	 If "Patient received palliative care" equals  "1 - Yes" THEN "If yes, for how long?, AND "Location of Palliative Care" AND "Types of palliative care received" fields are Mandatory  
-	AND IF "Types of palliative care received" contains "Other" THEN "If other type, specify" field is mandatory 
OR
-	 if "Patient received palliative care?" equals "2 - No" then "If no, was palliative care accessible" field is mandatory 
-	  EXCEPTIONS: 
-	(1) If Patient required palliative care? field equals "Do not know" Rule 25 does not apply, 
-	(2) If "Case Type Reported Date -/= 2022-12-31 fields "Location of Palliative Care" and Types of palliative care received" are not required  

Current Logic : (1 AND 2) OR (2 AND 3 AND 4) OR (2 AND 5 AND 6) OR (7 AND (8 OR 9)) OR (7 AND 10 AND 1) OR ( 7 AND 10 AND 5 AND 6) OR (7 AND 10 AND 3 AND 4 AND 11 AND 14 AND ((12 AND 13) OR (NOT(12))))


Rule 26 : BCMOHAD – 14196
Section: Disability Support      
New Variable Added with Variable :  Disability support services received-  Disability_support_services_received__c. field-meta.xml  - {!Var1634_Disability_support_services_received} , Other supports, specify - Other_supports_specify__c. field-meta.xml  - Var1634_Other_supports_specify                                                                                                                                                                                                               
 Rule 26:  

-	If "Patient needs disability support services" equals "1-Yes" then "If yes, did the patient received disability" is mandatory. 
-	AND IF "if yes, did the patieint received disability" field equals "1 - Yes" THEN "Disability support services received" AND "If yes, for how long?" fields are mandatory  
-	AND if "Disability support services received" contains "Other supports" THEN "Other supports, specify" field is Mandatory OR  If "If yes, did patient received disability" field equals  "2- No" THEN "If no, were services accessible?" field is required                                            
       EXCEPTIONS: 
-	If "Patient needs disability support services" equals "3 - Do not know" THEN Rule 26 does not apply  
-	OR if "Case Type Reported Date" equals -/= 2022-12-31 THEN "Disability support services received" field is NOT Mandatory 
-	if yes, did the patieint received disability" – BY PASS THE RULES

Current Logic - 3 OR ((1 OR 10) AND 2) OR ((1 OR 10) AND 4 AND 5) OR ((1 OR 10) AND 4 AND 7 AND 6) OR (1 AND 4 AND 8 AND 9) OR (10 AND 4 AND 8 AND 9 AND 12 AND ((11 AND 13) OR (NOT(11))))


Rule 33: BCMOHAD – 14197

Rule 33: 
New Variable Added : Reasons for transfer -  Reasons_for_transfer__c.field-meta.xml - Var1634_Reasons_for_transfer , Specify other transfer reason - Specify_other_transfer_reason__c. .field-meta.xml - Var1634_Specify_other_transfer_reason, Name_of_facility_if_due_to_MAiD_policy__c. field-meta.xml  -Var1634_Name_of_facility_if_due_to_MAiD_policy  ,1634 Page layout Changes , Permission set ( Maid Analyst , Maid Manager)

	As per Lara Request :- Need to Put back on Page layout : Was patient transferred due to facility policy? but for only Admin not for others.

-	IF "Was patient transferred for MAiD" equals "1 - Yes" THEN "Was patient transferred due to facility policy?" OR "Reasons for transfer" is Mandatory
-	AND IF "Reasons for transfer" contains "Other" THEN "Specify other transfer reason" field is mandatory OR if "Reasons for transfer" includes"Policies of the facility where the person was located" THEN "Name of Facility if due to MAiD policy" is mandatory.          
     
-	 EXCEPTION: If "Was patient transferred for MAiD" equals "2 - No" OR "3 - Do not know" Rule 33 does NOT apply 

Current Logic - (3 AND 7) OR 5 OR 8 OR ( (14 AND 4 AND ( 2 OR 9) )  AND ( (12 AND 10)  OR (NOT(12)) ) AND ( (13 AND 11) OR (NOT(13)) ) AND (1 OR 6))

 Rule : 42  BCMOHAD – 14198
 No New Variable Added , only Just condition Logic change.
The following 1634 form fields are mandatory to close CASE:                                                                                                                                    

Section: Request details                                                                                                                                                                                                                                                          
-Prior patient consultation 
-Who did you receive the request from?
-Date of Written request received                                                                                                                                                                                                                                                                    
-Written or verbal request date                                                                                                                                                                                                                
Section: Assessment Details 
-Assessment Date 
-Assessment conducted
-Location of Assessment 


EXCEPTION: 
-	If Case Type Report Date" IS -/= 2022-12-31 THEN "Who did you receive the request from?"AND "Written or verbal request date" are not Mandatory    Only for written is not mandatory for 2022.
-	
 Current Logic : ((( 14 AND 1 AND 2 AND 3 AND 4 AND 5 AND 6 ) OR (1 AND 2 AND 3 AND 4 AND 5 AND 6 AND 13)) AND (7 OR 8 OR 9)) OR (10 AND 11 AND 12)

Rule 50 – BCMOHAD 14201

Section: Discontinuation of Planning                                                                                                                                                                                               
New Variable : If_other_specify__c. field-meta.xml   - Var1634_If_other_specify, If_known_reasons_for_withdrawal__c . field-meta.xml   -Var1634_If_known_reasons_for_withdrawal , Specify_other_withdrawal_reason__c. . field-meta.xml   Var1634_Specify_other_withdrawal_reason , Withdrawal_means_to_relieve_suffering__c. field-meta.xml -   Var1634_Withdrawal_means_to_relieve_suffering , Other_relief_means_specify__c. . field-meta.xml  Var1634_Other_relief_means_specify , 1634 Page layout Changes , Permission set ( Maid Analyst , Maid Manager)

Rule 50:
-	 If "Patient withdrew request" is TRUE then  
-	"If_the_patient_withdrew_request_what_we__c" OR "If known, reasons for withdrawal"  field is mandatory AND  
-	if  "If_the_patient_withdrew_request_what_we__c"(Loop)  contains "4-Other" THEN "If_other_specify__c" field is mandatory AND 
-	"If known, reasons for withdrawal" contains "Other reason" THEN "Specify other withdrawal reason" field is mandatory. AND 
-	If "Case Type Reported Date" =/+ 2023-01-01 THEN "Withdrawal means to relieve suffering" is mandatory AND 
-	IF "Withdrawal means to relieve suffering" contains "Other" THEN "Other relief means, specify:" field is mandatory  

Current Logic : (( 1  AND (2 AND (3 OR 9)) AND ((4 AND 5) OR (NOT(4))) AND ( (10 AND 11) OR (NOT(10))) AND (( 8 AND 12) OR 15) AND ( ( (8 AND 13 AND 14) OR (NOT(13)) ) OR 15 )  )   OR 6 )  OR 7



















