### PR TITLE
 BCMOHAD-14461  || Rule  42 & 58 changes

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -1743,7 +1743,7 @@
         <defaultConnectorLabel>Rule 42 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_42_Pass</name>
-            <conditionLogic>((( 14 AND 1 AND 2 AND 3 AND 4 AND 5 AND 6 ) OR (1 AND 2 AND 3 AND 4 AND 5 AND 6 AND 13)) AND (7 OR 8 OR 9)) OR (10 AND 11 AND 12)</conditionLogic>
+            <conditionLogic>((( 14 AND 1 AND 2 AND 3 AND 4 AND 5 AND 6 ) OR (1 AND 2 AND 3 AND 4 AND 5 AND 6 AND 13 AND 15)) AND (7 OR 8 OR 9)) OR (10 AND 11 AND 12)</conditionLogic>
             <conditions>
                 <leftValueReference>Var1634_PriorPatientConsultation</leftValueReference>
                 <operator>IsNull</operator>
@@ -1838,6 +1838,10 @@
                 <rightValue>
                     <elementReference>VarCase_CaseTypeReporteddate</elementReference>
                 </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_Patient_required_palliative_care</leftValueReference>
+                <operator>NotEqualTo</operator>
             </conditions>
             <connector>
                 <targetReference>Rule_21</targetReference>
@@ -2920,7 +2924,7 @@
         <defaultConnectorLabel>Rule 58 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_58_Skipped</name>
-            <conditionLogic>1 AND (2 OR 3 OR 4)</conditionLogic>
+            <conditionLogic>1 AND (2 OR 3 OR 4) AND (5 OR 6)</conditionLogic>
             <conditions>
                 <leftValueReference>Var1634_Is1633Checked</leftValueReference>
                 <operator>EqualTo</operator>
@@ -2947,6 +2951,20 @@
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.X1633__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>No</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.X1633__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Incomplete</stringValue>
                 </rightValue>
             </conditions>
             <connector>
@@ -3316,7 +3334,7 @@
             <label>Skip Rule</label>
         </rules>
     </decisions>
-    <description>Rule : 46 is completing with All changes..!</description>
+    <description>Final Copy : Rule : 42 &amp; 58 Changes are done...!</description>
     <environments>Default</environments>
     <formulas>
         <name>FormatedAddSemicolon</name>


### PR DESCRIPTION
Flow Mandatory 

No New Variable Added for fields , Only decision logic change 
 Rule : 42

We are missing one mandatory field for 2023+ cases (it should be “Written or verbal request date” and “Patient required palliative care?”


RULE 58 Exception (same exception as Rule 57 & 60) 

FORM 1633                                                                                                                                                                                                                                           
Rule 58: The following 1633 form fields must be completed for CASE field "Mandatory Data" Flow to close case required to close case Criteria: the fields listed are mandatory to close file:                                                                                                                                                                                                                                                                                                                               
Assessment Date 
Assessment conducted
Location of Assessment   AND IF "Location of Assessment" equals 2-Facilty - Site is selected in "Location of Assessment" field then "If Facility/Site, specify Facility & Unit" field is required OR IF "Location of Assessment" Field equals "3 - Other" then "If Other location, specify" field is required
 
Exceptions: If case types (Discontinuation of Planning - Death Prior, Discontinuation of Planning - Ineligible, or Discontinuation of Planning - Patient Withdrawal) AND (1633 form entered field is ticket on the 1634 form) ****_OR (1633 Form on Case equals “No or Incomplete”)_****  Bypass Rule 
