### PR TITLE
BCMOHAD-14584 || Rule 46 Change

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -2048,7 +2048,7 @@
         <defaultConnectorLabel>Rule 46 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_46_Pass</name>
-            <conditionLogic>(  ( (1 AND 2) OR ( 1 AND 4 AND 3) )  AND ( 6 OR 7 OR 8) )  OR  5 OR  ( 9 AND 10 AND 11)</conditionLogic>
+            <conditionLogic>(  ( (1 AND 2) OR ( 1 AND 12 AND 4 AND 3 AND 13) )  AND ( 6 OR 7 OR 8) )  OR  5 OR  ( 9 AND 10 AND 11)</conditionLogic>
             <conditions>
                 <leftValueReference>Var1634_Is1633Checked</leftValueReference>
                 <operator>EqualTo</operator>
@@ -2124,6 +2124,17 @@
                 <operator>NotEqualTo</operator>
                 <rightValue>
                     <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Older_MAiD_Forms_to_2021__c</leftValueReference>
+                <operator>NotEqualTo</operator>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Older_MAiD_Forms_to_2021__c</leftValueReference>
+                <operator>NotEqualTo</operator>
+                <rightValue>
+                    <stringValue>No</stringValue>
                 </rightValue>
             </conditions>
             <connector>
@@ -3348,7 +3359,7 @@
             <label>Skip Rule</label>
         </rules>
     </decisions>
-    <description>Rule 68 Update</description>
+    <description>Rule 46 Update: Requested by Lara : 30 March 2023</description>
     <environments>Default</environments>
     <formulas>
         <name>FormatedAddSemicolon</name>


### PR DESCRIPTION
Mandatory Flow

Rule 46: If "1633 Form" field on 1634 form is TRUE AND "Case Type Reported Date" -/= 2022-12-31 OR (If “Case Type Reported Date” equal or greater than 2023-01-01 AND 1633 Form Entered on 1634 form is “True” Date of Assessment is less that 2023-01-01) THEN the following section are NOT mandatory on the 1634: Consulted other health care professionals, "Patient received palliative care", "Patient needs disability support service" AND “Patient required palliative care?”

Added Condition Logic  : 12 & 13
(  ( (1 AND 2) OR ( 1 AND 12 AND 4 AND 3 AND 13) )  AND ( 6 OR 7 OR 8) )  OR  5 OR  ( 9 AND 10 AND 11)

Older MAid Forms 2021 : No  & Not Blank