### PR TITLE
BCMOHAD-14824 Rules 57, 58, 25 Updated

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -2762,7 +2762,7 @@
         <defaultConnectorLabel>Rule 57 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_57_Skipped</name>
-            <conditionLogic>(3 OR 4 OR 5) AND (1 OR 2 OR 6 OR 7)</conditionLogic>
+            <conditionLogic>((3 OR 4 OR 5) AND (1 OR 2 OR 6 OR 7)) OR (1 AND (8 OR 9))</conditionLogic>
             <conditions>
                 <leftValueReference>Var1633_Assessor_did_not_receive_1632</leftValueReference>
                 <operator>Contains</operator>
@@ -2810,6 +2810,20 @@
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Incomplete</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Not Foreseeable</stringValue>
                 </rightValue>
             </conditions>
             <connector>
@@ -2900,7 +2914,7 @@
         <defaultConnectorLabel>Rule 58 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_58_Skipped</name>
-            <conditionLogic>1 AND (2 OR 3 OR 4) AND (5 OR 6)</conditionLogic>
+            <conditionLogic>(1 AND (2 OR 3 OR 4) AND (5 OR 6)) OR (9 AND (7 OR 8))</conditionLogic>
             <conditions>
                 <leftValueReference>Var1634_Is1633Checked</leftValueReference>
                 <operator>EqualTo</operator>
@@ -2941,6 +2955,27 @@
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Incomplete</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Death Not Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1633_Assessor_did_not_receive_1632</leftValueReference>
+                <operator>Contains</operator>
+                <rightValue>
+                    <stringValue>1- Yes</stringValue>
                 </rightValue>
             </conditions>
             <connector>
@@ -3317,7 +3352,7 @@
             <label>Skip Rule</label>
         </rules>
     </decisions>
-    <description> Rule 46 changes Reverted to Original Version</description>
+    <description>Rule 57, 58, Updated</description>
     <environments>Default</environments>
     <formulas>
         <name>FormatedAddSemicolon</name>

--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -1327,7 +1327,7 @@
                 <leftValueReference>Var1634_Types_of_palliative_care_received</leftValueReference>
                 <operator>Contains</operator>
                 <rightValue>
-                    <stringValue>Other</stringValue>
+                    <stringValue>Other Care Service</stringValue>
                 </rightValue>
             </conditions>
             <conditions>

--- a/MAiD - Case Management App/force-app/main/default/objects/Form_1634__c/fields/Types_of_palliative_care_received__c.field-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/objects/Form_1634__c/fields/Types_of_palliative_care_received__c.field-meta.xml
@@ -62,7 +62,7 @@
                 <label>Do not know</label>
             </value>
             <value>
-                <fullName>Other</fullName>
+                <fullName>Other Care Service</fullName>
                 <default>false</default>
                 <label>Other</label>
             </value>


### PR DESCRIPTION
# Description
**Mandatory_Data.flow-meta.xml** 
**Objects/Form_1634__c/Fields/Types_of_palliative_care_received__c**
Rules 57, 58, 25 Updated.
**Rule 57, 58** : There were missing an exception to Bypass these rules so lara asked us to add an exception to bypass this rule for Maid death forseable and Maid death Not forseable cases.

**Rule 25**: There was Scenario failing whenever the field : "Types of Palliative care received" contains Other so this is fixed by changes the picklist value to "Other Care Service" 

Fixes # (issue)- BCMOHAD-14824

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# List high-level changes as bullet items:
**Rule 57, 58** : There were missing an exception to Bypass these rules so lara asked us to add an exception to bypass this rule for Maid death forseable and Maid death Not forseable cases.

**Rule 25**: There was Scenario failing whenever the field : "Types of Palliative care received" contains Other so this is fixed by changes the picklist value to "Other Care Service" 

Below are some examples

- [] Changed field permissions
- [] changed field data-type

# Deployment Tracker

[List all the metadata that is pushed in this commit/PR. Full URL should be fine.] https://github.com/bcgov/MOH-MAiD/pull/614

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
