### PR TITLE
BCMOHAD-14463 Rule 60 Updated

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Provincial_and_RX_Flow_for_1633.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Provincial_and_RX_Flow_for_1633.flow-meta.xml
@@ -243,8 +243,8 @@
     <decisions>
         <name>check_60_Rule_0</name>
         <label>check 60 Rule</label>
-        <locationX>1441</locationX>
-        <locationY>714</locationY>
+        <locationX>1444</locationX>
+        <locationY>713</locationY>
         <defaultConnector>
             <targetReference>ErrorMessage60</targetReference>
         </defaultConnector>
@@ -273,7 +273,7 @@
         </rules>
         <rules>
             <name>rule_60_check_0</name>
-            <conditionLogic>(1 OR (2 AND 3 AND 4))</conditionLogic>
+            <conditionLogic>((1 OR (2 AND 3 AND 4))) OR ((5 OR 6) AND (7 OR 8))</conditionLogic>
             <conditions>
                 <leftValueReference>Var1633_Patient_Consent</leftValueReference>
                 <operator>EqualTo</operator>
@@ -297,6 +297,34 @@
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>1 - Is capable of providing informed consent</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Death Prior</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>check_if_1633_is_ticked</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>ListCaseDetail.X1633__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>No</stringValue>
                 </rightValue>
             </conditions>
             <connector>
@@ -1208,7 +1236,8 @@
             <label>Check if 1633 is ticked on 1634</label>
         </rules>
     </decisions>
-    <description>1633 field check condition is updated..!</description>
+    <description>Rule 60 Updated</description>
+    <environments>Default</environments>
     <interviewLabel>Provincial and RX Flow for 1633 {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Provincial and RX Flow for 1633</label>
     <processMetadataValues>
@@ -1478,6 +1507,7 @@
         <queriedFields>Id</queriedFields>
         <queriedFields>Federal_Safeguards__c</queriedFields>
         <queriedFields>Type</queriedFields>
+        <queriedFields>X1633__c</queriedFields>
     </recordLookups>
     <recordLookups>
         <name>GetRecordsForm1633</name>


### PR DESCRIPTION
# Description

Rule 60 Bypass exception added
Exception: If case type is "Discontinuation of Planning - Death Prior" OR  "Discontinuation of Planning - Patient Withdrawal" AND "1633 form entered" field is TRUE on the 1634 form OR If "1633 form" on case equal "No" THEN Rule 60 does not apply  

Fixes # (BCMOHAD-14463)

## Type of change

- [Yes] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# List high-level changes as bullet items
Exception: If case type is "Discontinuation of Planning - Death Prior" 
OR 
 "Discontinuation of Planning - Patient Withdrawal" 
AND 
"1633 form entered" field is TRUE on the 1634 form 
OR
If "1633 form" on case equal "No" THEN Rule 60 does not apply 

Below are some examples

- [ ] Changed field permissions
- [ ] changed field data-type

# Deployment Tracker

List all the metadata that is pushed in this commit/PR. Full URL should be fine.
https://github.com/bcgov/MOH-MAiD/pull/619

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
