### PR TITLE
BCMOHAD-14994 Rule 57 Updated

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -2769,7 +2769,7 @@
         <defaultConnectorLabel>Rule 57 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_57_Skipped</name>
-            <conditionLogic>((3 OR 4 OR 5) AND (1 OR 2 OR 6 OR 7)) OR (1 AND (8 OR 9))</conditionLogic>
+            <conditionLogic>((3 OR 4 OR 5) AND (1 OR 2 OR 6)) OR (1 AND (7 OR 8))</conditionLogic>
             <conditions>
                 <leftValueReference>Var1633_Assessor_did_not_receive_1632</leftValueReference>
                 <operator>Contains</operator>
@@ -2807,16 +2807,9 @@
             </conditions>
             <conditions>
                 <leftValueReference>ListCaseDetail.X1633__c</leftValueReference>
-                <operator>EqualTo</operator>
+                <operator>NotEqualTo</operator>
                 <rightValue>
-                    <stringValue>No</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>ListCaseDetail.X1633__c</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>Incomplete</stringValue>
+                    <stringValue></stringValue>
                 </rightValue>
             </conditions>
             <conditions>
@@ -3359,7 +3352,7 @@
             <label>Skip Rule</label>
         </rules>
     </decisions>
-    <description>Rule 48 Updated</description>
+    <description>Rule 57 Updated</description>
     <environments>Default</environments>
     <formulas>
         <name>FormatedAddSemicolon</name>


### PR DESCRIPTION
# Description

 .Rule 57 Updated:
 the field on case "X1633__c"  is NotEqualTo Null condition added
                                 
Fixes # (BCMOHAD-14994)

## Type of change

- [YES] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# List high-level changes as bullet items
 the field on case "X1633__c"  is NotEqualTo Null condition added

Below are some examples

- [ ] Changed field permissions
- [ ] changed field data-type

# Deployment Tracker

List all the metadata that is pushed in this commit/PR. Full URL should be fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
