### PR TITLE
BCMOHAD-14995 Rule 58 Update

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -2914,7 +2914,7 @@
         <defaultConnectorLabel>Rule 58 Fail</defaultConnectorLabel>
         <rules>
             <name>Rule_58_Skipped</name>
-            <conditionLogic>(1 AND (2 OR 3 OR 4) AND (5 OR 6)) OR (9 AND (7 OR 8))</conditionLogic>
+            <conditionLogic>(1 AND (2 OR 3 OR 4) AND 5) OR (8 AND (6 OR 7))</conditionLogic>
             <conditions>
                 <leftValueReference>Var1634_Is1633Checked</leftValueReference>
                 <operator>EqualTo</operator>
@@ -2945,17 +2945,7 @@
             </conditions>
             <conditions>
                 <leftValueReference>ListCaseDetail.X1633__c</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>No</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>ListCaseDetail.X1633__c</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>Incomplete</stringValue>
-                </rightValue>
+                <operator>NotEqualTo</operator>
             </conditions>
             <conditions>
                 <leftValueReference>ListCaseDetail.Type</leftValueReference>
@@ -3352,7 +3342,7 @@
             <label>Skip Rule</label>
         </rules>
     </decisions>
-    <description>Rule 57 Updated</description>
+    <description>Rule 58 Updated</description>
     <environments>Default</environments>
     <formulas>
         <name>FormatedAddSemicolon</name>


### PR DESCRIPTION
# Description

Rule 57 Updated:
the field on case "X1633__c" is NotEqualTo Null condition added

Fixes # (BCMOHAD-14995)

## Type of change

- [ YES] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# List high-level changes as bullet items
the field on case "X1633__c" is NotEqualTo Null condition added

Below are some examples

- [ ] Changed field permissions
- [ ] changed field data-type

# Deployment Tracker

List all the metadata that is pushed in this commit/PR. Full URL should be fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
