### PR TITLE
BCMOHAD-14981 || Fix Duplicate PHN flow.

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/MAiD_Prevent_Duplicate_Phn.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/MAiD_Prevent_Duplicate_Phn.flow-meta.xml
@@ -2,92 +2,38 @@
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>57.0</apiVersion>
     <decisions>
-        <name>check_for_maid_phn</name>
-        <label>check for maid phn</label>
-        <locationX>111</locationX>
-        <locationY>857</locationY>
+        <name>Compare_individual_records</name>
+        <label>Compare individual records</label>
+        <locationX>528</locationX>
+        <locationY>551</locationY>
         <defaultConnector>
-            <targetReference>loop_for_maid</targetReference>
+            <targetReference>Looping_through_Case_Records</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
-            <name>maid_phn_match</name>
-            <conditionLogic>and</conditionLogic>
+            <name>Case_1_Check_if_entered_PHN_is_equal_to_Looping_record_PHN</name>
+            <conditionLogic>1 AND (2 OR 3 OR 4)</conditionLogic>
             <conditions>
-                <leftValueReference>loop_for_maid.PHN__c</leftValueReference>
+                <leftValueReference>Looping_through_Case_Records.PHN__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <elementReference>$Record.PHN__c</elementReference>
                 </rightValue>
             </conditions>
-            <connector>
-                <targetReference>update_prevent_phn</targetReference>
-            </connector>
-            <label>maid phn match</label>
-        </rules>
-    </decisions>
-    <decisions>
-        <name>check_for_match</name>
-        <label>check for match</label>
-        <locationX>560</locationX>
-        <locationY>797</locationY>
-        <defaultConnector>
-            <targetReference>Loop_to_check_phn</targetReference>
-        </defaultConnector>
-        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
-        <rules>
-            <name>match</name>
-            <conditionLogic>and</conditionLogic>
             <conditions>
-                <leftValueReference>Loop_to_check_phn.PHN__c</leftValueReference>
+                <leftValueReference>$Record.Type</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
-                    <elementReference>$Record.PHN__c</elementReference>
+                    <stringValue>MAiD Death Foreseeable</stringValue>
                 </rightValue>
             </conditions>
-            <connector>
-                <targetReference>Update_record_prvnt_phn</targetReference>
-            </connector>
-            <label>match</label>
-        </rules>
-    </decisions>
-    <decisions>
-        <name>check_for_same</name>
-        <label>check for same</label>
-        <locationX>843</locationX>
-        <locationY>581</locationY>
-        <defaultConnector>
-            <targetReference>look_for_phn</targetReference>
-        </defaultConnector>
-        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
-        <rules>
-            <name>phn_match1</name>
-            <conditionLogic>and</conditionLogic>
             <conditions>
-                <leftValueReference>look_for_phn.PHN__c</leftValueReference>
+                <leftValueReference>$Record.Type</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
-                    <elementReference>$Record.PHN__c</elementReference>
+                    <stringValue>MAiD Death Not Foreseeable</stringValue>
                 </rightValue>
             </conditions>
-            <connector>
-                <targetReference>dup_phn_prev</targetReference>
-            </connector>
-            <label>phn match1</label>
-        </rules>
-    </decisions>
-    <decisions>
-        <name>Check_if_case_type_is_MAiD_Assessment_of_Eligibility</name>
-        <label>Check if case type is MAiD Assessment of Eligibility</label>
-        <locationX>430</locationX>
-        <locationY>479</locationY>
-        <defaultConnector>
-            <targetReference>Get_Type_Of_Cases</targetReference>
-        </defaultConnector>
-        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
-        <rules>
-            <name>MAiD_Assessment_of_Eligibility</name>
-            <conditionLogic>and</conditionLogic>
             <conditions>
                 <leftValueReference>$Record.Type</leftValueReference>
                 <operator>EqualTo</operator>
@@ -95,90 +41,61 @@
                     <stringValue>MAiD Assessment of Eligibility</stringValue>
                 </rightValue>
             </conditions>
-            <conditions>
-                <leftValueReference>$Record.Status</leftValueReference>
-                <operator>NotEqualTo</operator>
-                <rightValue>
-                    <stringValue>Closed</stringValue>
-                </rightValue>
-            </conditions>
             <connector>
-                <targetReference>Get_Cases_type_is_MAiD_Assessment_of_Eligibility</targetReference>
+                <targetReference>Update_Prevent_duplicate_flag</targetReference>
             </connector>
-            <label>MAiD Assessment of Eligibility</label>
+            <label>Case-1 [Check if entered PHN is equal to Looping record PHN]</label>
         </rules>
         <rules>
-            <name>Discontinuation_of_Planning_Ineligible</name>
-            <conditionLogic>and</conditionLogic>
+            <name>Case_2_Check_if_entered_PHN_is_equal_to_Looping_record_PHN</name>
+            <conditionLogic>1 AND (2 OR 3 OR 4)</conditionLogic>
+            <conditions>
+                <leftValueReference>Looping_through_Case_Records.PHN__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>$Record.PHN__c</elementReference>
+                </rightValue>
+            </conditions>
             <conditions>
                 <leftValueReference>$Record.Type</leftValueReference>
-                <operator>EqualTo</operator>
+                <operator>NotEqualTo</operator>
                 <rightValue>
-                    <stringValue>Discontinuation of Planning – Ineligible</stringValue>
+                    <stringValue>MAiD Death Foreseeable</stringValue>
                 </rightValue>
             </conditions>
-            <connector>
-                <targetReference>Get_Discontinuation_of_Planning_Ineligible</targetReference>
-            </connector>
-            <label>Discontinuation of Planning – Ineligible</label>
-        </rules>
-    </decisions>
-    <decisions>
-        <name>Check_if_maid_case</name>
-        <label>Check if maid case</label>
-        <locationX>584</locationX>
-        <locationY>359</locationY>
-        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
-        <rules>
-            <name>Maid_Case</name>
-            <conditionLogic>and</conditionLogic>
             <conditions>
-                <leftValueReference>$Record.RecordType.Name</leftValueReference>
-                <operator>EqualTo</operator>
+                <leftValueReference>$Record.Type</leftValueReference>
+                <operator>NotEqualTo</operator>
                 <rightValue>
-                    <stringValue>Maid Case</stringValue>
+                    <stringValue>MAiD Death Not Foreseeable</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Type</leftValueReference>
+                <operator>NotEqualTo</operator>
+                <rightValue>
+                    <stringValue>MAiD Assessment of Eligibility</stringValue>
                 </rightValue>
             </conditions>
             <connector>
-                <targetReference>Check_if_case_type_is_MAiD_Assessment_of_Eligibility</targetReference>
+                <targetReference>Update_Prevent_duplicate_flag_Warning_message</targetReference>
             </connector>
-            <label>Maid Case</label>
+            <label>Case-2 [Check if entered PHN is equal to Looping record PHN]</label>
         </rules>
     </decisions>
     <environments>Default</environments>
     <interviewLabel>Maid Prevent Duplicate Phn {!$Flow.CurrentDateTime}</interviewLabel>
     <label>MAiD Prevent Duplicate Phn</label>
     <loops>
-        <name>look_for_phn</name>
-        <label>look for phn</label>
-        <locationX>710</locationX>
-        <locationY>606</locationY>
-        <collectionReference>Get_Cases_type_is_MAiD_Assessment_of_Eligibility</collectionReference>
+        <description>Iterate over cases that have same PHN that was entered/updated.</description>
+        <name>Looping_through_Case_Records</name>
+        <label>Looping through Case Records</label>
+        <locationX>176</locationX>
+        <locationY>431</locationY>
+        <collectionReference>Fetch_all_cases_with_PHN</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
-            <targetReference>check_for_same</targetReference>
-        </nextValueConnector>
-    </loops>
-    <loops>
-        <name>loop_for_maid</name>
-        <label>loop for maid</label>
-        <locationX>298</locationX>
-        <locationY>719</locationY>
-        <collectionReference>Get_Cases_type_is_MAiD_Assessment_of_Eligibility</collectionReference>
-        <iterationOrder>Asc</iterationOrder>
-        <nextValueConnector>
-            <targetReference>check_for_maid_phn</targetReference>
-        </nextValueConnector>
-    </loops>
-    <loops>
-        <name>Loop_to_check_phn</name>
-        <label>Loop to check phn</label>
-        <locationX>449</locationX>
-        <locationY>745</locationY>
-        <collectionReference>Get_Discontinuation_of_Planning_Ineligible</collectionReference>
-        <iterationOrder>Asc</iterationOrder>
-        <nextValueConnector>
-            <targetReference>check_for_match</targetReference>
+            <targetReference>Compare_individual_records</targetReference>
         </nextValueConnector>
     </loops>
     <processMetadataValues>
@@ -190,7 +107,7 @@
     <processMetadataValues>
         <name>CanvasMode</name>
         <value>
-            <stringValue>FREE_FORM_CANVAS</stringValue>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
         </value>
     </processMetadataValues>
     <processMetadataValues>
@@ -201,27 +118,49 @@
     </processMetadataValues>
     <processType>AutoLaunchedFlow</processType>
     <recordLookups>
-        <name>Get_Cases_type_is_MAiD_Assessment_of_Eligibility</name>
-        <label>Get Cases type is MAiD Assessment of Eligibility</label>
-        <locationX>298</locationX>
-        <locationY>599</locationY>
+        <description>To fetch all cases in the org which has the same PHN that is entered/updated by the user.</description>
+        <name>Fetch_all_cases_with_PHN</name>
+        <label>Fetch all cases with PHN</label>
+        <locationX>176</locationX>
+        <locationY>311</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
-            <targetReference>loop_for_maid</targetReference>
+            <targetReference>Looping_through_Case_Records</targetReference>
         </connector>
-        <filterLogic>(1 and 2) or ((3 or 4) and 5) and 6</filterLogic>
+        <filterLogic>(1 AND 2 AND (3 OR 4 OR 5 OR 6 OR 7 OR 8 OR 9 OR 10))</filterLogic>
+        <filters>
+            <field>PHN__c</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>$Record.PHN__c</elementReference>
+            </value>
+        </filters>
+        <filters>
+            <field>RecordTypeId</field>
+            <operator>EqualTo</operator>
+            <value>
+                <stringValue>0125W0000004KYUQA2</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Type</field>
+            <operator>Contains</operator>
+            <value>
+                <stringValue>MAiD Death Foreseeable</stringValue>
+            </value>
+        </filters>
         <filters>
             <field>Type</field>
             <operator>EqualTo</operator>
             <value>
-                <stringValue>MAiD Assessment of Eligibility</stringValue>
+                <stringValue>MAiD Death Not Foreseeable</stringValue>
             </value>
         </filters>
         <filters>
-            <field>Status</field>
-            <operator>NotEqualTo</operator>
+            <field>Type</field>
+            <operator>EqualTo</operator>
             <value>
-                <stringValue>Closed</stringValue>
+                <stringValue>Discontinuation of Planning: Death Prior</stringValue>
             </value>
         </filters>
         <filters>
@@ -239,50 +178,22 @@
             </value>
         </filters>
         <filters>
-            <field>Status</field>
+            <field>Type</field>
             <operator>EqualTo</operator>
             <value>
-                <stringValue>Closed</stringValue>
+                <stringValue>Preliminary Assessment</stringValue>
             </value>
         </filters>
-        <filters>
-            <field>RecordTypeId</field>
-            <operator>EqualTo</operator>
-            <value>
-                <elementReference>$Record.RecordTypeId</elementReference>
-            </value>
-        </filters>
-        <getFirstRecordOnly>false</getFirstRecordOnly>
-        <object>Case</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordLookups>
-    <recordLookups>
-        <name>Get_Discontinuation_of_Planning_Ineligible</name>
-        <label>Get Discontinuation of Planning – Ineligible</label>
-        <locationX>450</locationX>
-        <locationY>628</locationY>
-        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
-        <connector>
-            <targetReference>Loop_to_check_phn</targetReference>
-        </connector>
-        <filterLogic>and</filterLogic>
         <filters>
             <field>Type</field>
             <operator>EqualTo</operator>
             <value>
-                <stringValue>Discontinuation of Planning – Ineligible</stringValue>
-            </value>
-        </filters>
-        <filters>
-            <field>RecordTypeId</field>
-            <operator>EqualTo</operator>
-            <value>
-                <elementReference>$Record.RecordTypeId</elementReference>
+                <stringValue>Transfer of Request</stringValue>
             </value>
         </filters>
         <filters>
             <field>Type</field>
-            <operator>NotEqualTo</operator>
+            <operator>EqualTo</operator>
             <value>
                 <stringValue>MAiD Assessment of Eligibility</stringValue>
             </value>
@@ -291,101 +202,105 @@
         <object>Case</object>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordLookups>
-    <recordLookups>
-        <name>Get_Type_Of_Cases</name>
-        <label>Get Type Of Cases</label>
-        <locationX>664</locationX>
-        <locationY>500</locationY>
-        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+    <recordUpdates>
+        <name>Update_Prevent_duplicate_flag</name>
+        <label>Update Prevent duplicate flag</label>
+        <locationX>264</locationX>
+        <locationY>671</locationY>
+        <inputAssignments>
+            <field>Prevent_save_on_duplicate_PHN__c</field>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <recordUpdates>
+        <name>Update_Prevent_duplicate_flag_Warning_message</name>
+        <label>Update Prevent duplicate flag &amp; Warning message</label>
+        <locationX>528</locationX>
+        <locationY>671</locationY>
         <connector>
-            <targetReference>look_for_phn</targetReference>
+            <targetReference>Looping_through_Case_Records</targetReference>
         </connector>
-        <filterLogic>and</filterLogic>
+        <inputAssignments>
+            <field>Warning_Message_If_Any__c</field>
+            <value>
+                <stringValue>There is an existing MAiD Death case with this PHN</stringValue>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Fetch_all_cases_with_PHN</targetReference>
+        </connector>
+        <filterLogic>(1 AND ( 2 OR 3 OR 4 OR 5 OR 6 OR 7 OR 8 OR 9))</filterLogic>
         <filters>
-            <field>Type</field>
+            <field>RecordTypeId</field>
             <operator>EqualTo</operator>
             <value>
-                <elementReference>$Record.Type</elementReference>
+                <stringValue>0125W0000004KYUQA2</stringValue>
             </value>
         </filters>
         <filters>
             <field>Type</field>
-            <operator>NotEqualTo</operator>
+            <operator>Contains</operator>
+            <value>
+                <stringValue>MAiD Death Foreseeable</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Type</field>
+            <operator>Contains</operator>
+            <value>
+                <stringValue>MAiD Death Not Foreseeable</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Type</field>
+            <operator>Contains</operator>
             <value>
                 <stringValue>Discontinuation of Planning: Death Prior</stringValue>
             </value>
         </filters>
         <filters>
             <field>Type</field>
-            <operator>NotEqualTo</operator>
+            <operator>Contains</operator>
+            <value>
+                <stringValue>Discontinuation of Planning: Ineligible</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Type</field>
+            <operator>Contains</operator>
+            <value>
+                <stringValue>Discontinuation of Planning: Withdrawn Request</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Type</field>
+            <operator>Contains</operator>
+            <value>
+                <stringValue>Preliminary Assessment</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Type</field>
+            <operator>Contains</operator>
+            <value>
+                <stringValue>Transfer of Request</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Type</field>
+            <operator>Contains</operator>
             <value>
                 <stringValue>MAiD Assessment of Eligibility</stringValue>
             </value>
         </filters>
-        <filters>
-            <field>RecordTypeId</field>
-            <operator>EqualTo</operator>
-            <value>
-                <elementReference>$Record.RecordTypeId</elementReference>
-            </value>
-        </filters>
-        <filters>
-            <field>Status</field>
-            <operator>NotEqualTo</operator>
-            <value>
-                <stringValue>Closed</stringValue>
-            </value>
-        </filters>
-        <object>Case</object>
-        <outputReference>templist</outputReference>
-        <queriedFields>Id</queriedFields>
-        <queriedFields>PHN__c</queriedFields>
-    </recordLookups>
-    <recordUpdates>
-        <name>dup_phn_prev</name>
-        <label>dup phn prev</label>
-        <locationX>887</locationX>
-        <locationY>707</locationY>
-        <inputAssignments>
-            <field>Prevent_save_on_duplicate_PHN__c</field>
-            <value>
-                <booleanValue>true</booleanValue>
-            </value>
-        </inputAssignments>
-        <inputReference>$Record</inputReference>
-    </recordUpdates>
-    <recordUpdates>
-        <name>update_prevent_phn</name>
-        <label>update prevent phn</label>
-        <locationX>719</locationX>
-        <locationY>890</locationY>
-        <inputAssignments>
-            <field>Prevent_save_on_duplicate_PHN__c</field>
-            <value>
-                <booleanValue>true</booleanValue>
-            </value>
-        </inputAssignments>
-        <inputReference>$Record</inputReference>
-    </recordUpdates>
-    <recordUpdates>
-        <name>Update_record_prvnt_phn</name>
-        <label>Update record prvnt phn</label>
-        <locationX>705</locationX>
-        <locationY>739</locationY>
-        <inputAssignments>
-            <field>Prevent_save_on_duplicate_PHN__c</field>
-            <value>
-                <booleanValue>true</booleanValue>
-            </value>
-        </inputAssignments>
-        <inputReference>$Record</inputReference>
-    </recordUpdates>
-    <start>
-        <locationX>458</locationX>
-        <locationY>48</locationY>
-        <connector>
-            <targetReference>Check_if_maid_case</targetReference>
-        </connector>
         <object>Case</object>
         <recordTriggerType>CreateAndUpdate</recordTriggerType>
         <triggerType>RecordBeforeSave</triggerType>


### PR DESCRIPTION
# Description
This pull request includes change to fix duplicate PHN issue faced in higher environments. 

- Same PHN for different Case Type status !=> Closed is a PASS
- Same PHN for same cast type that is open would be FAIL. Stopping to saving and Error notification.
- Is the PHN equal to the same as Open MAID open assessment of eligibility. Then error notification otherwise PASS. (ONLY for MAiD Case type)
- Just on all closed cases, does PHN exists in previous cases. Show notification PASS.

Fixes # (issue)
https://proactionca.ent.cgi.com/jira/browse/BCMOHAD-14981

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# List high-level changes as bullet items

- [X] Merged two existing flows into one by handling both conditions in 1 flow.

# Deployment Tracker

- MAiD - Case Management App/force-app/main/default/flows/MAiD_Prevent_Duplicate_Phn.flow-meta.xml

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
