### PR TITLE
BCMOHAD-15040 Rule 50 Update

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Mandatory_Data.flow-meta.xml
@@ -2265,7 +2265,7 @@
         </rules>
         <rules>
             <name>Rule_50_Pass</name>
-            <conditionLogic>(( 1  AND (2 AND (3 OR 9)) AND ((4 AND 5) OR (NOT(4))) AND ( (10 AND 11) OR (NOT(10))) AND (( 8 AND 12) OR 15) AND ( ( (8 AND 13 AND 14) OR (NOT(13)) ) OR 15 )  )   OR 6 )  OR 7</conditionLogic>
+            <conditionLogic>(( 1  AND (2 AND (3 OR 9)) AND ((4 AND 5) OR (NOT(4))) AND ( (10 AND 11) OR (NOT(10))) AND ((8 AND ((16 AND 12) OR  (NOT(12)))) OR 15) AND ( ( (8 AND 13 AND 14) OR (NOT(13)) ) OR 15 )  )   OR 6 )  OR 7</conditionLogic>
             <conditions>
                 <leftValueReference>ListCaseDetail.Type</leftValueReference>
                 <operator>EqualTo</operator>
@@ -2357,6 +2357,13 @@
                 <operator>LessThan</operator>
                 <rightValue>
                     <elementReference>VarCase_CaseTypeReporteddate</elementReference>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Var1634_If_known_reasons_for_withdrawal</leftValueReference>
+                <operator>Contains</operator>
+                <rightValue>
+                    <stringValue>Accepted the means to relieve their suffering</stringValue>
                 </rightValue>
             </conditions>
             <connector>
@@ -3342,7 +3349,7 @@
             <label>Skip Rule</label>
         </rules>
     </decisions>
-    <description>Rule 58 Updated</description>
+    <description>Rule 50 Updated</description>
     <environments>Default</environments>
     <formulas>
         <name>FormatedAddSemicolon</name>


### PR DESCRIPTION
# Description
 “Withdrawal means to relieving suffering” if only required if 1634 field “if known, reasons for withdrawal” contains “Accepted the means to relieve their suffering” otherwise “Withdrawal means to relieving suffering” should be NULL.

Above Logic implemented

Fixes # (BCMOHAD-15040)

## Type of change

- [YES] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# List high-level changes as bullet items
Withdrawal means to relieving suffering” if only required if 1634 field “if known, reasons for withdrawal” contains “Accepted the means to relieve their suffering” otherwise “Withdrawal means to relieving suffering” should be NULL.

Above Logic implemented

Below are some examples

- [ ] Changed field permissions
- [ ] changed field data-type

# Deployment Tracker

List all the metadata that is pushed in this commit/PR. Full URL should be fine.
https://github.com/bcgov/MOH-MAiD/pull/629

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
