### PR TITLE
BCMOHAD-16512-v1 || Updated Flow and form 1641 field

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flows/Federal_Safeguards.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Federal_Safeguards.flow-meta.xml
@@ -1625,7 +1625,7 @@
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>CheckRule19_yes_0</name>
-            <conditionLogic>(((1 AND 2) OR (3 AND 4) OR 8) AND 9 AND 10 AND 11 AND 5 AND 6 AND 7 AND 12)</conditionLogic>
+            <conditionLogic>(((1 AND 2) OR (3 AND 4) OR 8) AND 9 AND 10 AND 5 AND 6 AND 7 AND 11)</conditionLogic>
             <conditions>
                 <leftValueReference>Var1645_PatientSafeguardsCompleted</leftValueReference>
                 <operator>EqualTo</operator>
@@ -1691,13 +1691,6 @@
                 <operator>EqualTo</operator>
                 <rightValue>
                     <elementReference>Varbool</elementReference>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1645_Finalwaiverofconsentdatesigned</leftValueReference>
-                <operator>LessThan</operator>
-                <rightValue>
-                    <elementReference>Var1634_MAiDAdministrationDate</elementReference>
                 </rightValue>
             </conditions>
             <conditions>
@@ -2026,7 +2019,7 @@
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>Rule_66_Pass</name>
-            <conditionLogic>(1 AND ((2 AND (((3 AND 4 AND 7) AND ((5 AND 6) OR (NOT(5))) ) OR (NOT(3)))) OR (8 AND  (13 AND (9 OR 10)) AND (NOT(2)) AND (7 AND (11 OR 12)) AND (NOT(4))))) OR (NOT(1))</conditionLogic>
+            <conditionLogic>(1 AND 2 AND (((3 AND 4 AND 7) AND ((5 AND 6) OR (NOT(5))) ) OR (NOT(3)))) OR (NOT(1))</conditionLogic>
             <conditions>
                 <leftValueReference>ListCaseDetail.Case_Type_Reported_Date__c</leftValueReference>
                 <operator>GreaterThanOrEqualTo</operator>
@@ -2064,52 +2057,13 @@
                 <leftValueReference>Var1634_AdvanceStateOfIrreversibleDecline</leftValueReference>
                 <operator>NotEqualTo</operator>
             </conditions>
-            <conditions>
-                <leftValueReference>ListCaseDetail.Type</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>Discontinuation of Planning: Ineligible</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_Patienthasseriousandincurableillnes</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>2 - No</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_Patienthasseriousandincurableillnes</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>3 - Did not assess</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_AdvanceStateOfIrreversibleDecline</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>2 - No</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_AdvanceStateOfIrreversibleDecline</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <stringValue>3 - Did not assess</stringValue>
-                </rightValue>
-            </conditions>
-            <conditions>
-                <leftValueReference>Var1634_Patienthasseriousandincurableillnes</leftValueReference>
-                <operator>NotEqualTo</operator>
-            </conditions>
             <connector>
                 <targetReference>UpdateFedralPASS</targetReference>
             </connector>
             <label>Rule 66 Pass</label>
         </rules>
     </decisions>
-    <description>Rule 66 Update</description>
+    <description>Rule 19 update: Removed the 11 condition (Var1645_Finalwaiverofconsentdatesignes less-than Var1634_MAiDAdministrationDate)</description>
     <environments>Default</environments>
     <formulas>
         <name>VarNumberofDays</name>
@@ -2345,10 +2299,6 @@
         <outputAssignments>
             <assignToReference>Var1634_Discussedmeansofalleviatingsuffering</assignToReference>
             <field>Patient_has_discussed_and_considered_mea__c</field>
-        </outputAssignments>
-        <outputAssignments>
-            <assignToReference>Var1634_Patienthasseriousandincurableillnes</assignToReference>
-            <field>Patient_has_serious_and_incurable_illnes__c</field>
         </outputAssignments>
         <outputAssignments>
             <assignToReference>Var1634_AdvanceStateOfIrreversibleDecline</assignToReference>
@@ -2935,13 +2885,6 @@
     <variables>
         <name>Var1634_Patienthasbeeninformedofriskoflos</name>
         <dataType>Boolean</dataType>
-        <isCollection>false</isCollection>
-        <isInput>false</isInput>
-        <isOutput>false</isOutput>
-    </variables>
-    <variables>
-        <name>Var1634_Patienthasseriousandincurableillnes</name>
-        <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
         <isOutput>false</isOutput>

--- a/MAiD - Case Management App/force-app/main/default/objects/Form_1641__c/fields/Where_was_the_substance_dispensed__c.field-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/objects/Form_1641__c/fields/Where_was_the_substance_dispensed__c.field-meta.xml
@@ -13,7 +13,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>1 - Hospital</fullName>
-                <default>true</default>
+                <default>false</default>
                 <label>1 - Hospital</label>
             </value>
             <value>


### PR DESCRIPTION
# Description

Made the changes in Federal Safeguards flow in rule 19 as per Lara's recommendation.
Removed the Var1645_Finalwaiverofconsentdatesigned LessThan Var1634_MAiDAdministrationDate condition
Removed the Default value to the Where was the substance field in form 1641 object.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Deployment Tracker

MAiD - Case Management App/force-app/main/default/flows/Federal_Safeguards.flow-meta.xml
MAiD - Case Management App/force-app/main/default/objects/Form_1641__c/fields/Where_was_the_substance_dispensed__c.field-meta.xml

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
