### PR TITLE
BCMOHAD-24670 || Deleting the Manager 2 Permission set Group

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/permissionsetgroups/MAiD_Manager_2_Group.permissionsetgroup-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsetgroups/MAiD_Manager_2_Group.permissionsetgroup-meta.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PermissionSetGroup xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>MAiD Manager 2 Group</description>
-    <label>MAiD Manager 2 Group</label>
-    <permissionSets>MAiD_Analyst</permissionSets>
-    <permissionSets>MAiD_Manager</permissionSets>
-    <permissionSets>MAiD_Analyst_Reports_Dashboards</permissionSets>
-    <status>Updated</status>
-</PermissionSetGroup>


### PR DESCRIPTION
# Description

Deleting the Permission set group

**POST DeploymentStep:**
Delete **MAiD Manager 2** Group permission set group


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# Deployment Tracker

MAiD - Case Management App/force-app/main/default/permissionsetgroups/MAiD_Manager_2_Group.permissionsetgroup-meta.xml

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
