### PR TITLE
BCMOHAD-26373 -  Update reopen referral visibility

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/flexipages/ICY_Referral_Record_Page.flexipage-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flexipages/ICY_Referral_Record_Page.flexipage-meta.xml
@@ -44,7 +44,7 @@
                         <valueListItems>
                             <value>Referral__c.ICY_Reopen_Referral</value>
                             <visibilityRule>
-                                <booleanFilter>(1 OR 2) AND 3</booleanFilter>
+                                <booleanFilter>(1 OR 2) AND 3 AND 4</booleanFilter>
                                 <criteria>
                                     <leftValue>{!$User.UserRole.Name}</leftValue>
                                     <operator>CONTAINS</operator>
@@ -59,6 +59,11 @@
                                     <leftValue>{!Record.Status__c}</leftValue>
                                     <operator>EQUAL</operator>
                                     <rightValue>Closed</rightValue>
+                                </criteria>
+                                <criteria>
+                                    <leftValue>{!Record.Is_Related_Intake_Closed__c}</leftValue>
+                                    <operator>EQUAL</operator>
+                                    <rightValue>false</rightValue>
                                 </criteria>
                             </visibilityRule>
                         </valueListItems>

--- a/MAiD - Case Management App/force-app/main/default/flows/ICY_Intake_Reopen_Flow.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/ICY_Intake_Reopen_Flow.flow-meta.xml
@@ -60,6 +60,12 @@
             </value>
         </filters>
         <inputAssignments>
+            <field>Is_Related_Intake_Closed__c</field>
+            <value>
+                <booleanValue>false</booleanValue>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
             <field>Status__c</field>
             <value>
                 <stringValue>Ready for Intake</stringValue>

--- a/MAiD - Case Management App/force-app/main/default/flows/Intake_Close_Flow.flow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/flows/Intake_Close_Flow.flow-meta.xml
@@ -187,6 +187,12 @@
             </value>
         </filters>
         <inputAssignments>
+            <field>Is_Related_Intake_Closed__c</field>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
             <field>Status__c</field>
             <value>
                 <stringValue>Closed</stringValue>

--- a/MAiD - Case Management App/force-app/main/default/objects/Referral__c/fields/Is_Related_Intake_Closed__c.field-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/objects/Referral__c/fields/Is_Related_Intake_Closed__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Is_Related_Intake_Closed__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Field updated in flow and used in lightning Record page to manage visibility of Reopen Referral Button</description>
+    <externalId>false</externalId>
+    <label>Is Related Intake Closed</label>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/MAiD - Case Management App/force-app/main/default/permissionsets/ICY_Integrate_Permissions.permissionset-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/permissionsets/ICY_Integrate_Permissions.permissionset-meta.xml
@@ -1619,6 +1619,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Referral__c.Is_Related_Intake_Closed__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Referral__c.Is_Team_member__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# Description

BCMOHAD-26373 -  Update reopen referral visibility

Fixes # (BCMOHAD-26373)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


POST DEPLOYMENT STEPS TO RUN IN UAT,PROD ( QA ALREADY DONE)
================================================
To Update historical Data for Field  Is_Related_Intake_Closed__c on Referral Object follow below steps:

1) Disable all Active Validation Rules on Referral Object 

2) Run below Query to extract PROD Intake closed record:
select Id,Status__C from Intake__c where Status__c='Closed'


3) Run Data Import/update on same file extracted above 

4) Enable previously deactivated Validation Rules on Referral Object 

# Deployment Tracker

List all the metadata that is pushed in this commit/PR. Full URL should be fine.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
