### PR TITLE
BCMOHAM-21852 - 101 SOQL Error-Governor Limit Fixed in displaying the notes on the case.

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/classes/ICY_Notes_Documents_Controller.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ICY_Notes_Documents_Controller.cls
@@ -20,6 +20,7 @@ public with sharing class ICY_Notes_Documents_Controller {
         Id parentRecordId = Id.valueOf(recordId);
         List<Note> result = new List<Note>();
         List<ICY_Notes__c> caseNotes = new List<ICY_Notes__c>();
+        Boolean isProgramLeader = false;
         final String ADMIN_NOTES_TYPE = 'Administrative Notes';
 
         if(parentRecordId.getSobjectType() == Schema.Referral__c.SObjectType)
@@ -50,6 +51,10 @@ public with sharing class ICY_Notes_Documents_Controller {
             Description__c,ICY_Meeting_Date__c, Referral_Subject__c, CreatedDate, CreatedBy.Name,CreatedById, LastModifiedDate, LastModifiedBy.Name,
             Notes_Type__c,Other__c, Attendees__c, Length_of_Meeting__c FROM ICY_Notes__c WHERE Intake__c = :parentRecordId ORDER BY CreatedDate desc];
 
+
+        // verify the role for the current running user if he is a Program leader
+        isProgramLeader = YTS_Utility.lookupRole('Program Leader');
+
         for(ICY_Notes__c n: caseNotes){
             String subject = n.Referral_Subject__c == 'Other' ? n.Other__c: n.Referral_Subject__c;
             String modifiedDate = YTS_Utility.dateFormat_eeeeMMMdyyyy(n.LastModifiedDate);
@@ -58,7 +63,7 @@ public with sharing class ICY_Notes_Documents_Controller {
             String teamMember = parentRecordId.getSobjectType() == Schema.Case.SObjectType?n.Team_Member__c:'';
             String modeLocation = parentRecordId.getSobjectType() == Schema.Case.SObjectType?n.Mode_Location__c:'';
            // To be able to Edit a note either you are the creator of the notes or the PL and the note type shouldn't be = Restricted
-            Boolean canEdit = (((n.CreatedById == UserInfo.getUserId()) ||(YTS_Utility.lookupRole('Program Leader'))) && (n.Notes_Type__c=='Collaborative'))? true : false;
+            Boolean canEdit = (((n.CreatedById == UserInfo.getUserId()) || isProgramLeader ) && (n.Notes_Type__c=='Collaborative'))? true : false;
             
             result.add(
                 new Note(


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Query running inside the for loop for the fetching the role for the current running user is moved out of the for loop and 101 SOQL Error-Governor Limit Fixed accordingly.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# List high-level changes as bullet items
used a new boolean variable for checking the if the role of the current running user is program leader and passed into the for loop for the evaluation furthur

Below are some examples

- [ ] Changed field permissions
- [ ] changed field data-type

# Deployment Tracker

List all the metadata that is pushed in this commit/PR. Full URL should be fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
