### PR TITLE
BCMOHAD-31155-Revert- Reverting DKIM changes

### DIFF
--- a/MAiD - Case Management App/force-app/main/default/classes/YTS_Utility.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/YTS_Utility.cls
@@ -78,7 +78,7 @@ public with sharing class YTS_Utility {
      * Retrive org wide email address Id
      */
     public static Id getICYOrgWideEmailAddressId(){
-        List<OrgWideEmailAddress> addresses = [select id, Address, DisplayName from OrgWideEmailAddress WHERE DisplayName='Integrate Notifications' LIMIT 1];
+        List<OrgWideEmailAddress> addresses = [select id, Address, DisplayName from OrgWideEmailAddress WHERE DisplayName='Integrate Support' LIMIT 1];
         Id orgwideEmailId;
         if(addresses.size() > 0){
             orgwideEmailId = addresses[0].Id;

--- a/MAiD - Case Management App/force-app/main/default/classes/YTS_Utility_Test.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/YTS_Utility_Test.cls
@@ -1,0 +1,151 @@
+@isTest
+public class YTS_Utility_Test {
+
+    @testSetup static void testSetup() {
+        // Create a test Referral record to get record type ID
+        Referral__c testReferral = new Referral__c();
+        testReferral.Individual_First_Name__c = 'Test';
+        testReferral.Individual_Last_Name__c = 'Referral';
+        testReferral.Individual_Date_of_Birth__c = System.today();
+        testReferral.Type_of_Referral__c = 'Organizational Referral';
+        testReferral.Referring_Organization__c = 'Test Organization';
+        insert testReferral;
+    }
+
+    @isTest static void testGetRecordTypeIdByDeveloperName() {
+        // Test with valid parameters
+        String recordTypeId = YTS_Utility.getRecordTypeIdByDeveloperName('Referral__c', 'ICY_General');
+        System.assertNotEquals(null, recordTypeId, 'Record type ID should be returned for valid parameters');
+        
+        // Test with blank objectApi
+        String resultBlankObject = YTS_Utility.getRecordTypeIdByDeveloperName('', 'PHS_Referral');
+        System.assertEquals(null, resultBlankObject, 'Should return null when objectApi is blank');
+        
+        // Test with blank recordTypeDeveloperName
+        String resultBlankRecordType = YTS_Utility.getRecordTypeIdByDeveloperName('Referral__c', '');
+        System.assertEquals(null, resultBlankRecordType, 'Should return null when recordTypeDeveloperName is blank');
+    }
+
+    @isTest static void testGetPicklistValues() {
+        // Test with valid object and field
+        Map<String, String> picklistValues = YTS_Utility.getPicklistValues('Referral__c', 'Individual_Gender__c');
+        System.assertNotEquals(null, picklistValues, 'Should return a map of picklist values');
+        System.assert(picklistValues.size() > 0, 'Picklist map should not be empty for valid field');
+        
+        // Test with blank objectApi
+        Map<String, String> resultBlankObject = YTS_Utility.getPicklistValues('', 'Individual_Gender__c');
+        System.assertEquals(true, resultBlankObject.isEmpty(), 'Should return empty map when objectApi is blank');
+        
+        // Test with blank fieldApi
+        Map<String, String> resultBlankField = YTS_Utility.getPicklistValues('Referral__c', '');
+        System.assertEquals(true, resultBlankField.isEmpty(), 'Should return empty map when fieldApi is blank');
+    }
+
+    @isTest static void testDateFormatEeeeMMdyyyyWithDateTime() {
+        DateTime testDateTime = DateTime.newInstance(2021, 11, 4, 14, 30, 0);
+        String formattedDate = YTS_Utility.dateFormat_eeeeMMMdyyyy(testDateTime);
+        System.assertNotEquals(null, formattedDate, 'Should return formatted date string');
+        System.assert(formattedDate.contains('Nov'), 'Should contain month abbreviation');
+        System.assert(formattedDate.contains('2021'), 'Should contain year');
+    }
+
+    @isTest static void testDateFormatMMMdyyyyWithDate() {
+        Date testDate = Date.newInstance(2021, 11, 4);
+        String formattedDate = YTS_Utility.dateFormat_MMMdyyyy(testDate);
+        System.assertEquals('Nov 4, 2021', formattedDate, 'Should return formatted date string MMM d, yyyy');
+        
+        // Test with null date
+        String resultNull = YTS_Utility.dateFormat_MMMdyyyy((Date) null);
+        System.assertEquals(null, resultNull, 'Should return null when date is null');
+    }
+
+    @isTest static void testDateFormatEeeeMMdyyyyWithDate() {
+        Date testDate = Date.newInstance(2021, 11, 4);
+        String formattedDate = YTS_Utility.dateFormat_eeeeMMMdyyyy(testDate);
+        System.assertNotEquals(null, formattedDate, 'Should return formatted date string');
+        System.assert(formattedDate.contains('Nov'), 'Should contain month abbreviation');
+        System.assert(formattedDate.contains('2021'), 'Should contain year');
+        
+        // Test with null date
+        String resultNull = YTS_Utility.dateFormat_eeeeMMMdyyyy((Date) null);
+        System.assertEquals(null, resultNull, 'Should return null when date is null');
+    }
+
+    @isTest static void testDateFormatMMMdyyyyWithDateTime() {
+        DateTime testDateTime = DateTime.newInstance(2021, 11, 4, 14, 30, 0);
+        String formattedDate = YTS_Utility.dateFormat_MMMdyyyy(testDateTime);
+        System.assertEquals('Nov 4, 2021', formattedDate, 'Should return formatted date string MMM d, yyyy');
+        
+        // Test with null datetime
+        String resultNull = YTS_Utility.dateFormat_MMMdyyyy((DateTime) null);
+        System.assertEquals(null, resultNull, 'Should return null when datetime is null');
+    }
+
+    @isTest static void testDateFormatYyyyMmDd() {
+        Date testDate = Date.newInstance(2021, 11, 4);
+        String formattedDate = YTS_Utility.dateFormat_yyyy_mm_dd(testDate);
+        System.assertEquals('2021-11-4', formattedDate, 'Should return formatted date string yyyy-MM-dd');
+        
+        // Test with null date
+        String resultNull = YTS_Utility.dateFormat_yyyy_mm_dd(null);
+        System.assertEquals(null, resultNull, 'Should return null when date is null');
+    }
+
+    @isTest static void testDateFormatMMMdyyyykma() {
+        DateTime testDateTime = DateTime.newInstance(2024, 1, 15, 16, 32, 0);
+        String formattedDate = YTS_Utility.dateFormat_MMMdyyyykma(testDateTime);
+        System.assertNotEquals(null, formattedDate, 'Should return formatted date string');
+        System.assert(formattedDate.contains('January'), 'Should contain month name');
+        System.assert(formattedDate.contains('2024'), 'Should contain year');
+        System.assert(formattedDate.contains('pm'), 'Should contain lowercase pm');
+    }
+
+    @isTest static void testGetICYOrgWideEmailAddressId() {
+        // This test verifies the method returns an ID or null based on org configuration
+        Id emailAddressId = YTS_Utility.getICYOrgWideEmailAddressId();
+        // Email address may or may not exist in test org, so just verify method executes without error
+        System.assert(true, 'Method should execute without throwing exception');
+    }
+
+    @isTest static void testLookupRole() {
+        // Test the lookupRole method
+        Boolean result = YTS_Utility.lookupRole('System');
+        System.assert(result != null, 'Method should return a boolean value');
+        
+        // Test with null parameter
+        Boolean resultWithNull = YTS_Utility.lookupRole(null);
+        System.assertEquals(false, resultWithNull, 'Should return false when role is null');
+        
+        // Test with empty string
+        Boolean resultWithEmpty = YTS_Utility.lookupRole('');
+        System.assertEquals(false, resultWithEmpty, 'Should return false when role is empty');
+    }
+
+    @isTest static void testIsTopRoleICY() {
+        // This test verifies the method executes and returns a boolean
+        Boolean isTopRole = YTS_Utility.isTopRoleICY();
+        System.assert(isTopRole != null, 'Method should return a boolean value');
+    }
+
+    @isTest static void testPicklistValuesForMultipleFields() {
+        // Test picklist values for different fields to ensure method works across different fields
+        Map<String, String> genderPicklist = YTS_Utility.getPicklistValues('Referral__c', 'Individual_Gender__c');
+        Map<String, String> typePicklist = YTS_Utility.getPicklistValues('Referral__c', 'Type_of_Referral__c');
+        
+        System.assert(genderPicklist.size() >= 0, 'Gender picklist map should be populated');
+        System.assert(typePicklist.size() >= 0, 'Type of Referral picklist map should be populated');
+    }
+
+    @isTest static void testDateFormatEdgeCases() {
+        // Test with first day of year
+        Date newYearDate = Date.newInstance(2021, 1, 1);
+        String newYearFormatted = YTS_Utility.dateFormat_MMMdyyyy(newYearDate);
+        System.assertEquals('Jan 1, 2021', newYearFormatted, 'Should format Jan 1 correctly');
+        
+        // Test with last day of year
+        Date lastDayDate = Date.newInstance(2021, 12, 31);
+        String lastDayFormatted = YTS_Utility.dateFormat_MMMdyyyy(lastDayDate);
+        System.assertEquals('Dec 31, 2021', lastDayFormatted, 'Should format Dec 31 correctly');
+    }
+
+}

--- a/MAiD - Case Management App/force-app/main/default/classes/YTS_Utility_Test.cls-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/classes/YTS_Utility_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/MAiD - Case Management App/force-app/main/default/triggers/ICY_SystemAccessRequestEmailTrigger.trigger
+++ b/MAiD - Case Management App/force-app/main/default/triggers/ICY_SystemAccessRequestEmailTrigger.trigger
@@ -1,7 +1,7 @@
 trigger ICY_SystemAccessRequestEmailTrigger on System_Access_Request__c (after insert) {
   List<Messaging.SingleEmailMessage> messageList = new List<Messaging.SingleEmailMessage>();
   OrgWideEmailAddress owea = new OrgWideEmailAddress();
-  owea=[select id,Address from OrgWideEmailAddress where displayname ='Integrate Notifications'];
+  owea=[select id,Address from OrgWideEmailAddress where displayname ='Integrate Support'];
   List<string> toAddress = new List<string>();
   toAddress.add(owea.Address);
   string emailTemplateName = 'ICY_Portal_Registration_Notification';

--- a/MAiD - Case Management App/force-app/main/default/workflows/Intake__c.workflow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/workflows/Intake__c.workflow-meta.xml
@@ -8,7 +8,7 @@
             <field>ICY_Assigned_To__c</field>
             <type>userLookup</type>
         </recipients>
-        <senderAddress>notifications@integratesupport.gov.bc.ca</senderAddress>
+        <senderAddress>pso.integratesupport@gov.bc.ca</senderAddress>
         <senderType>OrgWideEmailAddress</senderType>
         <template>ICY_Email_Templates/ICY_Intake_Assignment_Notification_Latest</template>
     </alerts>
@@ -19,7 +19,7 @@
         <recipients>
             <type>owner</type>
         </recipients>
-        <senderAddress>notifications@integratesupport.gov.bc.ca</senderAddress>
+        <senderAddress>pso.integratesupport@gov.bc.ca</senderAddress>
         <senderType>OrgWideEmailAddress</senderType>
         <template>ICY_Email_Templates/Intake_Ownership_Transfer</template>
     </alerts>

--- a/MAiD - Case Management App/force-app/main/default/workflows/Referral__c.workflow-meta.xml
+++ b/MAiD - Case Management App/force-app/main/default/workflows/Referral__c.workflow-meta.xml
@@ -7,7 +7,7 @@
         <recipients>
             <type>owner</type>
         </recipients>
-        <senderAddress>notifications@integratesupport.gov.bc.ca</senderAddress>
+        <senderAddress>pso.integratesupport@gov.bc.ca</senderAddress>
         <senderType>OrgWideEmailAddress</senderType>
         <template>ICY_Email_Templates/Referral_Ownership_Transfer</template>
     </alerts>
@@ -18,7 +18,7 @@
         <recipients>
             <type>owner</type>
         </recipients>
-        <senderAddress>notifications@integratesupport.gov.bc.ca</senderAddress>
+        <senderAddress>pso.integratesupport@gov.bc.ca</senderAddress>
         <senderType>OrgWideEmailAddress</senderType>
         <template>ICY_Email_Templates/Referral_Status_Closed_Template</template>
     </alerts>
@@ -29,7 +29,7 @@
         <recipients>
             <type>owner</type>
         </recipients>
-        <senderAddress>notifications@integratesupport.gov.bc.ca</senderAddress>
+        <senderAddress>pso.integratesupport@gov.bc.ca</senderAddress>
         <senderType>OrgWideEmailAddress</senderType>
         <template>ICY_Email_Templates/Referral_Owner_Email_Template</template>
     </alerts>
@@ -41,7 +41,7 @@
             <field>ICY_Assigned_To__c</field>
             <type>userLookup</type>
         </recipients>
-        <senderAddress>notifications@integratesupport.gov.bc.ca</senderAddress>
+        <senderAddress>pso.integratesupport@gov.bc.ca</senderAddress>
         <senderType>OrgWideEmailAddress</senderType>
         <template>ICY_Email_Templates/ICY_Referral_Updated_Template</template>
     </alerts>


### PR DESCRIPTION
# Description

BCMOHAD-31155-Revert- Reverting DKIM changes

Fixes # (BCMOHAD-31155)

PDS
======
1) Go to Setup/Email alert 
Edit each record below and update From Email Address to "Integrate Support" <pso.integratesupport@gov.bc.ca>"

Intake Assignment Notification Alert
Notify New Intake Owner
Notify new referral owner
Referral Closed Email Alert
Referral Record Email Alert
Referral Updated Email Alert

2)  Activate the email domain filters from Setup

 