### PR TITLE
BCMOHAM-34730 || Updated the class and the test class.

### DIFF
--- a/.github/workflows/deploy-sose-qa.yml
+++ b/.github/workflows/deploy-sose-qa.yml
@@ -26,11 +26,9 @@ jobs:
           echo ${{ secrets.SFDX_AUTH_URL_SOSE_QA }} | sf org login sfdx-url -s -u
 
       - name: "Validate"
-        working-directory: "MAiD - Case Management App"
         run: |
-          sf project deploy validate -d ./force-app/ -l RunLocalTests -w 30
+          sf project deploy validate -d "./MAiD - Case Management App/force-app/" -l RunLocalTests -w 30
 
       - name: "Deploy"
-        working-directory: "MAiD - Case Management App"
         run: |
-          sf project deploy start -d ./force-app/ -l RunLocalTests -w 30
+          sf project deploy start -d "./MAiD - Case Management App/force-app/" -l RunLocalTests -w 30

--- a/.github/workflows/deploy-sose-qa.yml
+++ b/.github/workflows/deploy-sose-qa.yml
@@ -27,8 +27,10 @@ jobs:
 
       - name: "Validate"
         run: |
-          sf project deploy validate -d "./MAiD - Case Management App/force-app/" -l RunLocalTests -w 30
+          cd "MAiD - Case Management App"
+          sf project deploy validate -d ./force-app/ -l RunLocalTests -w 30
 
       - name: "Deploy"
         run: |
-          sf project deploy start -d "./MAiD - Case Management App/force-app/" -l RunLocalTests -w 30
+          cd "MAiD - Case Management App"
+          sf project deploy start -d ./force-app/ -l RunLocalTests -w 30

--- a/.github/workflows/deploy-sose-qa.yml
+++ b/.github/workflows/deploy-sose-qa.yml
@@ -26,9 +26,11 @@ jobs:
           echo ${{ secrets.SFDX_AUTH_URL_SOSE_QA }} | sf org login sfdx-url -s -u
 
       - name: "Validate"
+        working-directory: "MAiD - Case Management App"
         run: |
           sf project deploy validate -d ./force-app/ -l RunLocalTests -w 30
 
       - name: "Deploy"
+        working-directory: "MAiD - Case Management App"
         run: |
           sf project deploy start -d ./force-app/ -l RunLocalTests -w 30

--- a/.github/workflows/validate-sose-qa.yml
+++ b/.github/workflows/validate-sose-qa.yml
@@ -27,4 +27,5 @@ jobs:
 
       - name: "Validate"
         run: |
-          sf project deploy validate -d "./MAiD - Case Management App/force-app/" -l RunLocalTests -w 30
+          cd "MAiD - Case Management App"
+          sf project deploy validate -d ./force-app/ -l RunLocalTests -w 30

--- a/.github/workflows/validate-sose-qa.yml
+++ b/.github/workflows/validate-sose-qa.yml
@@ -8,7 +8,7 @@ on:
       - opened
       - synchronize
     paths:
-      - "force-app/**"
+      - "MAiD - Case Management App/force-app/**"
 
 jobs:
   validate-deployment:
@@ -26,5 +26,6 @@ jobs:
           echo ${{ secrets.SFDX_AUTH_URL_SOSE_QA }} | sf org login sfdx-url -s -u
 
       - name: "Validate"
+        working-directory: "MAiD - Case Management App"
         run: |
           sf project deploy validate -d ./force-app/ -l RunLocalTests -w 30

--- a/.github/workflows/validate-sose-qa.yml
+++ b/.github/workflows/validate-sose-qa.yml
@@ -26,6 +26,5 @@ jobs:
           echo ${{ secrets.SFDX_AUTH_URL_SOSE_QA }} | sf org login sfdx-url -s -u
 
       - name: "Validate"
-        working-directory: "MAiD - Case Management App"
         run: |
-          sf project deploy validate -d ./force-app/ -l RunLocalTests -w 30
+          sf project deploy validate -d "./MAiD - Case Management App/force-app/" -l RunLocalTests -w 30

--- a/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandler.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandler.cls
@@ -100,8 +100,9 @@ public with sharing class ICY_CaseNotesHandler {
             u.UserRoleId != null &&
             u.UserRole.DeveloperName == System.Label.ICY_User_Role;
 
-        if (!hasExcludedRole) {
-            emails.add(u.Email);
+            if (!hasExcludedRole) {
+                emails.add(u.Email);
+            }
         }
 
         return new List<String>(emails);

--- a/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandler.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandler.cls
@@ -85,7 +85,7 @@ public with sharing class ICY_CaseNotesHandler {
         }
         Set<String> emails = new Set<String>();
         for(User u : [
-            SELECT Email
+            SELECT Email, UserRoleId, UserRole.DeveloperName
             FROM User
             WHERE IsActive = true
             AND Email != null
@@ -95,6 +95,12 @@ public with sharing class ICY_CaseNotesHandler {
                 WHERE GroupId IN :groupIds
             )
         ]) {
+            // Exclude users assigned to the ICY role.
+            Boolean hasExcludedRole =
+            u.UserRoleId != null &&
+            u.UserRole.DeveloperName == System.Label.ICY_User_Role;
+
+        if (!hasExcludedRole) {
             emails.add(u.Email);
         }
 

--- a/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandlerTest.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandlerTest.cls
@@ -2,23 +2,241 @@
 private class ICY_CaseNotesHandlerTest {
      @testSetup static void testSetup(){
         ICY_ReferralFeatureUtilityTest.setup();
-      }
+    }
 
     @IsTest
-    static void testReferralBasedNotesUpdate() {       
+    static void testReferralBasedNotesUpdate() {
         Referral__c ref = [Select Id From Referral__c LIMIT 1];
          // Create ICY Note linked to Intake, with null Case__c (should be updated when Intake.Case__c is populated)
         ICY_Notes__c n1 = new ICY_Notes__c(Referral__c =  ref.Id);
         ICY_Notes__c n2 = new ICY_Notes__c(Referral__c =  ref.Id);
-             
+
         insert new List<ICY_Notes__c>{ n1, n2 };
-     
-        // Re-query notes
-        n1 = [SELECT Id, Case__c, Referral__c FROM ICY_Notes__c WHERE Id = :n1.Id];
-        n2 = [SELECT Id, Case__c, Referral__c FROM ICY_Notes__c WHERE Id = :n2.Id];
-     
-        System.assertEquals(ref.Id, n1.Referral__c);
-     
+
+        List<Case> existingCases = [ SELECT Id, Referral__c FROM Case WHERE Referral__c = :ref.Id LIMIT 1
+        ];
+
+        Case testCase;
+
+        if (!existingCases.isEmpty()) {
+            testCase = existingCases[0];
+        } else {
+            testCase = new Case(
+                Referral__c = ref.Id,
+                Status = 'New',
+                Origin = 'Web'
+            );
+            insert testCase;
+        }
+
+        Test.startTest();
+
+        ICY_CaseNotesHandler.afterInsert(new List<Case>{testCase});
+
+        Test.stopTest();
+
+        List<ICY_Notes__c> updatedNotes = [
+            SELECT Id, Case__c, Referral__c, Note_Source__c FROM ICY_Notes__c
+            WHERE Id IN :new Set<Id>{ n1.Id, n2.Id }
+        ];
+
+        System.assertEquals(2, updatedNotes.size(), 'Both ICY Notes should be returned.');
+
+        for (ICY_Notes__c note : updatedNotes) {
+
+            System.assertEquals(ref.Id, note.Referral__c,'Referral should remain unchanged.');
+
+            System.assertEquals(testCase.Id, note.Case__c,'Case should be populated based on the Referral.');
+
+            System.assertEquals('Referral', note.Note_Source__c,'Note Source should be set to Referral.');
+        }
     }
 
+    @IsTest
+    static void testAfterInsertEmptyInput() {
+
+        Test.startTest();
+
+        ICY_CaseNotesHandler.afterInsert(null);
+
+        ICY_CaseNotesHandler.afterInsert(new List<Case>());
+
+        Test.stopTest();
+
+        System.assert(true);
+    }
+
+    @IsTest
+    static void testBlankGeographicArea() {
+
+        Test.startTest();
+
+        List<String> emails = ICY_CaseNotesHandler.getProgramLeaderEmailsByGeoArea(null);
+
+        List<String> blankEmails = ICY_CaseNotesHandler.getProgramLeaderEmailsByGeoArea('');
+
+        Test.stopTest();
+
+        System.assertEquals(0, emails.size(),'No emails should be returned for null Geographic Area.');
+
+        System.assertEquals(0, blankEmails.size(),'No emails should be returned for blank Geographic Area.');
+    }
+
+    @IsTest
+    static void testNoMatchingQueue() {
+
+        Test.startTest();
+
+        List<String> emails =
+            ICY_CaseNotesHandler.getProgramLeaderEmailsByGeoArea(
+                    'Test Area That Does Not Exist 12345'
+                );
+
+        Test.stopTest();
+
+        System.assertEquals(0, emails.size(),'No emails should be returned when no Queue is found.');
+    }
+
+    @IsTest
+    static void testProgramLeaderEmailsExcludesICYRole() {
+
+        String geoArea = 'Handler Test Area';
+
+        UserRole icyRole = getOrCreateICYRole();
+
+        User normalUser = createUser(
+            'normalpl',
+            null
+        );
+
+        User icyUser = createUser(
+            'icyrole',
+            icyRole.Id
+        );
+
+        insert new List<User>{
+            normalUser,
+            icyUser
+        };
+
+        Group programLeaderGroup = new Group(
+            Name = 'ICY Handler Test Program Leaders',
+            DeveloperName ='ICY_Handler_Test_Program_Leaders',
+            Type = 'Regular'
+        );
+
+        insert programLeaderGroup;
+
+        insert new List<GroupMember>{
+
+            new GroupMember(
+                GroupId = programLeaderGroup.Id,
+                UserOrGroupId = normalUser.Id
+            ),
+
+            new GroupMember(
+                GroupId = programLeaderGroup.Id,
+                UserOrGroupId = icyUser.Id
+            )
+        };
+
+
+        Group queue = new Group(
+            Name = 'ICY Queue - ' + geoArea,
+            DeveloperName ='ICY_Queue_Handler_Test_Area',
+            Type = 'Queue'
+        );
+
+        insert queue;
+
+
+        insert new GroupMember(
+            GroupId = queue.Id,
+            UserOrGroupId = programLeaderGroup.Id
+        );
+
+
+        Test.startTest();
+
+        List<String> emails = ICY_CaseNotesHandler.getProgramLeaderEmailsByGeoArea(geoArea);
+
+        Test.stopTest();
+
+        System.assert(emails.contains(normalUser.Email),'Normal Program Leader should receive the notification.');
+
+
+        System.assert(!emails.contains(icyUser.Email),'ICY Role user should be excluded from notifications.');
+
+
+        System.assertEquals( 1, emails.size(), 'Only non-ICY Role users should be returned.');
+    }
+
+    private static UserRole getOrCreateICYRole() {
+
+        String icyRoleDeveloperName = System.Label.ICY_User_Role;
+
+        List<UserRole> existingRoles = [
+            SELECT Id, Name, DeveloperName FROM UserRole
+            WHERE DeveloperName = :icyRoleDeveloperName
+            LIMIT 1
+        ];
+
+        if (!existingRoles.isEmpty()) {
+            return existingRoles[0];
+        }
+
+        UserRole role = new UserRole(
+            Name = 'ICY Test Role',
+            DeveloperName = icyRoleDeveloperName
+        );
+
+        insert role;
+
+        return role;
+    }
+
+
+    private static User createUser(
+        String uniqueName,
+        Id userRoleId
+    ) {
+
+        Profile profileRecord = [
+            SELECT Id FROM Profile WHERE UserType = 'Standard'
+            LIMIT 1
+        ];
+
+        String uniqueValue =
+            String.valueOf(DateTime.now().getTime()) +
+            uniqueName;
+
+        User testUser = new User(
+            FirstName = 'ICY',
+            LastName = 'Test ' + uniqueName,
+
+            Alias = uniqueName.length() > 8
+                ? uniqueName.substring(0, 8)
+                : uniqueName,
+
+            Email = uniqueValue + '@example.com',
+
+            Username = uniqueValue + '@example.com',
+
+            CommunityNickname = 'icy' + uniqueValue,
+
+            TimeZoneSidKey = 'America/Vancouver',
+
+            LocaleSidKey = 'en_CA',
+
+            EmailEncodingKey = 'UTF-8',
+
+            LanguageLocaleKey = 'en_US',
+
+            ProfileId = profileRecord.Id,
+
+            UserRoleId = userRoleId
+        );
+
+        return testUser;
+    }
 }

--- a/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandlerTest.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ICY_CaseNotesHandlerTest.cls
@@ -171,6 +171,7 @@ private class ICY_CaseNotesHandlerTest {
         System.assertEquals( 1, emails.size(), 'Only non-ICY Role users should be returned.');
     }
 
+    // Creates or retrieves the User Role matching ICY_User_Role
     private static UserRole getOrCreateICYRole() {
 
         String icyRoleDeveloperName = System.Label.ICY_User_Role;


### PR DESCRIPTION
# Description

Two users, Vartovnik, Dalibor and McInnes, Mark, are currently receiving all 90-day Inactive Case notifications because they are members of all Program Leader groups. Both users are PSO Admin accounts and should not receive these notifications.

Fixes # (issue)

Updated the notification logic to exclude users assigned to the ICY role from receiving Inactive Case notifications, as these are the only two users currently assigned to this role. The same approach used for Case Closed Notifications has been applied here for consistency.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
