### PR TITLE
BCMOHAM-34637 || Updated the apex classes and referral trigger

### DIFF
--- a/.github/workflows/deploy-sose-qa.yml
+++ b/.github/workflows/deploy-sose-qa.yml
@@ -27,10 +27,8 @@ jobs:
 
       - name: "Validate"
         run: |
-          cd "MAiD - Case Management App"
           sf project deploy validate -d ./force-app/ -l RunLocalTests -w 30
 
       - name: "Deploy"
         run: |
-          cd "MAiD - Case Management App"
-          sf project deploy start -d ./force-app/ -l RunLocalTests -w 30
+          sf project deploy start -d ./force-app/ -l RunLocalTests -w 30 --ignore-conflicts

--- a/MAiD - Case Management App/force-app/main/default/classes/ICY_Referral_Controller.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ICY_Referral_Controller.cls
@@ -132,6 +132,52 @@ public without sharing class ICY_Referral_Controller {
         }
 
     }
-
     
+    //Remove old ICY Intake shares and update Intake Owner when Referral Geographic Area changes
+	public static void removePreviousAreaIntakeShare(Set<Id> referralIds){
+        if(referralIds == null || referralIds.isEmpty()) return;
+    
+        Map<Id, Referral__c> referralMap = new Map<Id, Referral__c>([
+            SELECT Id, OwnerId
+            FROM Referral__c
+            WHERE Id IN :referralIds
+        ]);
+    
+        Set<Id> intakeIds = new Set<Id>();
+        List<Intake__c> intakesToUpdate = new List<Intake__c>();
+    
+        for(Intake__c i : [
+            SELECT Id, Referral__c, OwnerId
+            FROM Intake__c
+            WHERE Referral__c IN :referralIds
+        ]){
+            intakeIds.add(i.Id);
+    
+            //Update Intake Owner to the new Referral Owner
+            if(referralMap.containsKey(i.Referral__c) &&
+               i.OwnerId != referralMap.get(i.Referral__c).OwnerId){
+    
+                i.OwnerId = referralMap.get(i.Referral__c).OwnerId;
+                intakesToUpdate.add(i);
+            }
+        }
+    
+        if(!intakesToUpdate.isEmpty()){
+            UPDATE intakesToUpdate;
+        }
+    
+        if(intakeIds.isEmpty()) return;
+    
+        List<Intake__Share> sharesToDelete = [
+            SELECT Id
+            FROM Intake__Share
+            WHERE ParentId IN :intakeIds
+            AND RowCause = 'Case_Team_Member_Share__c'
+        ];
+    
+        if(!sharesToDelete.isEmpty()){
+            DELETE sharesToDelete;
+        }
+    }
+            
 }

--- a/MAiD - Case Management App/force-app/main/default/classes/ICY_Referral_ControllerTest.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ICY_Referral_ControllerTest.cls
@@ -6,50 +6,298 @@ public class ICY_Referral_ControllerTest {
         ICY_ReferralFeatureUtilityTest.setup();
 
     }
-
+	
     @isTest static void testMethods(){
         Referral__c ref = new Referral__c();
         ref.ICY_Personal_Health_Number__c = '9999999999';
         ref.Priority__c = 'High';
         insert ref;
-
+    
+        //Re-query because Referral automation may format/update the PHN
+        ref = [
+            SELECT Id, ICY_Personal_Health_Number__c, Priority__c
+            FROM Referral__c
+            WHERE Id = :ref.Id
+        ];
+    
         Case_Contact__c cs = [Select Id,Name From Case_Contact__c LIMIT 1];
         cs.Id = null;
         Case_Member__c objCaseM = new Case_Member__c();
-        objCaseM.Referral__c = ref.id;
+        objCaseM.Referral__c = ref.Id;
         objCaseM.ICY_Status__c = 'Active';
         insert objCaseM;
-
+    
         ICY_Document__c doc = new ICY_Document__c();
         doc.Referral__c = ref.Id;
         doc.Document_Type__c  = 'Restricted';
         insert doc;
-
+    
         Test.startTest();
         ICY_Referral_Controller.getPicklistvalues('Case_Member__c','ICY_Category_Assignment__c');
         ICY_Referral_Controller.getRecordTypeId('Case','ICY_Close_Case');
         ICY_Referral_Controller.getRecordTypeName(ref.Id);
-        ICY_Referral_Controller.createPrimaryContact(cs,ref.Id);
+    
+        String contactId =
+            ICY_Referral_Controller.createPrimaryContact(
+                cs,
+                ref.Id
+            );
+    
         ICY_Referral_Controller.isUserPartOfCaseMembers(ref.Id);
         ICY_Referral_Controller.getICYQueueId('Coast');
-        ICY_Referral_Controller.checkIfHealthNumberIsUnique('9999999999');
-        ICY_Referral_Controller.createICYIntakeRecord(ref.Id);
+    
+        Boolean duplicatePHN =
+            ICY_Referral_Controller.checkIfHealthNumberIsUnique(
+                ref.ICY_Personal_Health_Number__c
+            );
+    
+        String intakeId =
+            ICY_Referral_Controller.createICYIntakeRecord(ref.Id);
+    
+        Test.stopTest();
+    
+        System.assertEquals(
+            false,
+            duplicatePHN,
+            'PHN stored on the existing Referral should not be unique.'
+        );
+    
+        System.assertNotEquals(null, intakeId);
+    
+        Intake__c intake = [
+            SELECT Id, Referral__c, Priority__c
+            FROM Intake__c
+            WHERE Id = :intakeId
+        ];
+    
+        System.assertEquals(ref.Id, intake.Referral__c);
+        System.assertEquals(ref.Priority__c, intake.Priority__c);
+    
+        ICY_Document__c updatedDoc = [
+            SELECT Id, Intake__c
+            FROM ICY_Document__c
+            WHERE Id = :doc.Id
+        ];
+    
+        System.assertEquals(intake.Id, updatedDoc.Intake__c);
+    
+        Case_Contact__c updatedContact = [
+            SELECT Id, Intake__c
+            FROM Case_Contact__c
+            WHERE Id = :contactId
+        ];
+    
+        System.assertEquals(intake.Id, updatedContact.Intake__c);
+    }
+    
+    @isTest
+    static void testRemovePreviousAreaIntakeShare(){
+
+        Id queueId =
+            ICY_Referral_Controller.getICYQueueId('Coast');
+
+        Referral__c ref = new Referral__c();
+        ref.ICY_Personal_Health_Number__c = '7777777777';
+        ref.Priority__c = 'High';
+        ref.OwnerId = queueId;
+        insert ref;
+
+        String intakeId =
+            ICY_Referral_Controller.createICYIntakeRecord(ref.Id);
+
+        Intake__c intake = [
+            SELECT Id,
+                   Referral__c,
+                   OwnerId
+            FROM Intake__c
+            WHERE Id = :intakeId
+        ];
+
+        Intake__Share intakeShare = new Intake__Share(
+            ParentId = intake.Id,
+            UserOrGroupId = UserInfo.getUserId(),
+            AccessLevel = 'Edit',
+            RowCause =
+                Schema.Intake__Share.RowCause.Case_Team_Member_Share__c
+        );
+
+        insert intakeShare;
+
+        System.assertEquals(
+            1,
+            [
+                SELECT COUNT()
+                FROM Intake__Share
+                WHERE ParentId = :intake.Id
+                AND RowCause =
+                    'Case_Team_Member_Share__c'
+            ]
+        );
+
+        Test.startTest();
+
+        ICY_Referral_Controller.removePreviousAreaIntakeShare(
+            new Set<Id>{ref.Id}
+        );
+
         Test.stopTest();
 
-        Intake__c intake= [SELECT Id, Name, Referral__c, Priority__c FROM Intake__c WHERE Referral__c = :ref.Id limit 1];
-        System.assertEquals(ref.Priority__c, intake.Priority__c);
+        System.assertEquals(
+            0,
+            [
+                SELECT COUNT()
+                FROM Intake__Share
+                WHERE ParentId = :intake.Id
+                AND RowCause =
+                    'Case_Team_Member_Share__c'
+            ]
+        );
+    }
 
+
+    @isTest
+    static void testUpdateIntakeOwnerToReferralOwner(){
+
+        Referral__c ref = new Referral__c();
+        ref.ICY_Personal_Health_Number__c = '6666666666';
+        ref.Priority__c = 'High';
+        insert ref;
+
+        String intakeId =
+            ICY_Referral_Controller.createICYIntakeRecord(ref.Id);
+
+        Id newQueueId =
+            ICY_Referral_Controller.getICYQueueId('Coast');
+
+        ref.OwnerId = newQueueId;
+        update ref;
+
+        Test.startTest();
+
+        ICY_Referral_Controller.removePreviousAreaIntakeShare(
+            new Set<Id>{ref.Id}
+        );
+
+        Test.stopTest();
+
+        Intake__c updatedIntake = [
+            SELECT Id, OwnerId
+            FROM Intake__c
+            WHERE Id = :intakeId
+        ];
+
+        System.assertEquals(
+            newQueueId,
+            updatedIntake.OwnerId,
+            'Intake Owner should match Referral Owner.'
+        );
+    }
+
+
+    @isTest
+    static void testRemovePreviousAreaIntakeShareNoIntake(){
+
+        Referral__c ref = new Referral__c();
+        ref.ICY_Personal_Health_Number__c = '5555555555';
+        ref.Priority__c = 'High';
+        insert ref;
+
+        Test.startTest();
+
+        ICY_Referral_Controller.removePreviousAreaIntakeShare(
+            new Set<Id>{ref.Id}
+        );
+
+        Test.stopTest();
+
+        System.assertEquals(
+            0,
+            [
+                SELECT COUNT()
+                FROM Intake__c
+                WHERE Referral__c = :ref.Id
+            ]
+        );
+    }
+
+
+    @isTest
+    static void testRemovePreviousAreaIntakeShareEmptyInput(){
+
+        Test.startTest();
+
+        ICY_Referral_Controller.removePreviousAreaIntakeShare(null);
+        ICY_Referral_Controller.removePreviousAreaIntakeShare(
+            new Set<Id>()
+        );
+
+        Test.stopTest();
+
+        System.assert(true);
+    }
+
+
+    @isTest
+    static void testCreateIntakeException(){
+
+        Boolean exceptionThrown = false;
+
+        Test.startTest();
+
+        try{
+            ICY_Referral_Controller.createICYIntakeRecord(null);
+        }catch(Exception e){
+            exceptionThrown = true;
+        }
+
+        Test.stopTest();
+
+        System.assertEquals(
+            true,
+            exceptionThrown,
+            'Invalid Referral should result in an exception.'
+        );
+    }
+    
+    @isTest
+    static void testUniqueHealthNumber(){
+    
+        Referral__c ref = new Referral__c();
+        ref.ICY_Personal_Health_Number__c = '9999999998';
+        ref.Priority__c = 'High';
+        insert ref;
+    
+        //Re-query actual PHN after Referral automation has executed
+        ref = [
+            SELECT Id, ICY_Personal_Health_Number__c
+            FROM Referral__c
+            WHERE Id = :ref.Id
+        ];
+    
+        Test.startTest();
+    
+        Boolean duplicateResult =
+            ICY_Referral_Controller.checkIfHealthNumberIsUnique(
+                ref.ICY_Personal_Health_Number__c
+            );
+    
+        Boolean uniqueResult =
+            ICY_Referral_Controller.checkIfHealthNumberIsUnique(
+                '1234567890'
+            );
+    
+        Test.stopTest();
+    
+        System.assertEquals(
+            false,
+            duplicateResult,
+            'Existing Referral PHN should return false.'
+        );
+    
+        System.assertEquals(
+            true,
+            uniqueResult,
+            'A PHN that does not exist should return true.'
+        );
     }
 }
-
-   /* @isTest static void testMethods1(){
-
-        user u = [Select Id,Name from User Limit 1];
-        System.runAs(u) {
-            Referral__c ref = [Select Id,Name,ICY_Personal_Health_Number__c From Referral__c Limit 1];
-            ICY_Referral_Controller.createICYIntakeRecord(ref.Id);
-        }
-    }
-
-
-}*/

--- a/MAiD - Case Management App/force-app/main/default/classes/ReferralTriggerHandler.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ReferralTriggerHandler.cls
@@ -113,4 +113,24 @@ public class ReferralTriggerHandler {
             update accountsToUpdate;
         }
   }
+    
+    public static void handleGeographicAreaChange(
+        List<Referral__c> newReferrals,
+        Map<Id, Referral__c> oldReferralMap
+        ){
+        Set<Id> changedReferralIds = new Set<Id>();
+    
+        for(Referral__c r : newReferrals){
+            Referral__c oldR = oldReferralMap.get(r.Id);
+    
+            if(oldR != null &&
+               oldR.ICY_Geographic_Area__c != r.ICY_Geographic_Area__c){
+                changedReferralIds.add(r.Id);
+            }
+        }
+    
+        if(!changedReferralIds.isEmpty()){
+            ICY_Referral_Controller.removePreviousAreaIntakeShare(changedReferralIds);
+        }
+    } 
 }

--- a/MAiD - Case Management App/force-app/main/default/classes/ReferralTriggerTest.cls
+++ b/MAiD - Case Management App/force-app/main/default/classes/ReferralTriggerTest.cls
@@ -106,4 +106,69 @@ public class ReferralTriggerTest {
         System.assertEquals('9999-999-999', updatedCase.ICY_Ref_Personal_Health_Number__c);
         System.assertEquals('1985-12-25', updatedCase.ICY_Searchable_DOB__c);
     }
+    
+     @isTest
+    static void testRemovePreviousAreaIntakeShare(){
+
+        Id queueId =
+            ICY_Referral_Controller.getICYQueueId('Coast');
+
+        Referral__c ref = new Referral__c();
+        ref.ICY_Personal_Health_Number__c = '7777777777';
+        ref.Priority__c = 'High';
+        ref.OwnerId = queueId;
+        insert ref;
+
+        String intakeId =
+            ICY_Referral_Controller.createICYIntakeRecord(ref.Id);
+
+        Intake__c intake = [
+            SELECT Id,
+                   Referral__c,
+                   OwnerId
+            FROM Intake__c
+            WHERE Id = :intakeId
+        ];
+
+        Intake__Share intakeShare = new Intake__Share(
+            ParentId = intake.Id,
+            UserOrGroupId = UserInfo.getUserId(),
+            AccessLevel = 'Edit',
+            RowCause =
+                Schema.Intake__Share.RowCause.Case_Team_Member_Share__c
+        );
+
+        insert intakeShare;
+
+        System.assertEquals(
+            1,
+            [
+                SELECT COUNT()
+                FROM Intake__Share
+                WHERE ParentId = :intake.Id
+                AND RowCause =
+                    'Case_Team_Member_Share__c'
+            ]
+        );
+
+        Test.startTest();
+
+        ICY_Referral_Controller.removePreviousAreaIntakeShare(
+            new Set<Id>{ref.Id}
+        );
+
+        Test.stopTest();
+
+        System.assertEquals(
+            0,
+            [
+                SELECT COUNT()
+                FROM Intake__Share
+                WHERE ParentId = :intake.Id
+                AND RowCause =
+                    'Case_Team_Member_Share__c'
+            ]
+        );
+    }
+
 }

--- a/MAiD - Case Management App/force-app/main/default/triggers/ReferralTrigger.trigger
+++ b/MAiD - Case Management App/force-app/main/default/triggers/ReferralTrigger.trigger
@@ -1,3 +1,11 @@
 trigger ReferralTrigger on Referral__c (after insert, after update) {
+
+   if(Trigger.isUpdate){
+        ReferralTriggerHandler.handleGeographicAreaChange(
+            Trigger.new,
+            Trigger.oldMap
+        );
+    }
+
     ReferralTriggerHandler.handleAfterInsertOrUpdate(Trigger.new);
 }


### PR DESCRIPTION
# Description

After the Geographic Area was updated on the Referral and Case, a resource from the previous Geographic Area was still able to access the related Intake record, which was not expected.

Fixes # (issue)

The issue was caused by an existing Intake__Share record with Edit access and the Case_Team_Member_Share__c row cause. This share was created when the user originally accepted the Intake and was not removed when the Referral Geographic Area was changed.

The fix now detects Geographic Area changes through the Referral trigger/handler and:

1. Removes the existing Case_Team_Member_Share__c sharing records from the related Intake record(s).
2. Updates the related Intake Owner to match the updated Referral Owner, removing the previous Geographic Area queue/resource ownership that could continue to provide access.
3. Prevents resources from the previous Geographic Area from retaining access to the Intake after the transfer.